### PR TITLE
Add conjunction expansion specialization

### DIFF
--- a/examples/miner/2-conjunct/2-conjunct.scm
+++ b/examples/miner/2-conjunct/2-conjunct.scm
@@ -60,10 +60,10 @@
 ;; (cog-mine (cog-atomspace)
 ;;           #:minsup 2
 ;;           #:initpat (conjunct-pattern 2)
-;;           #:incremental-expansion #f)
+;;           #:conjunction-expansion #f)
 (define results (cog-mine (list AB BC DE EF)
                           #:minsup 2
                           #:initpat (conjunct-pattern 2)
-                          #:incremental-expansion #f
+                          #:conjunction-expansion #f
                           #:max-variables 4
                           #:surprisingness 'none))

--- a/examples/miner/mozi-ai/mine-mozi-ai.scm
+++ b/examples/miner/mozi-ai/mine-mozi-ai.scm
@@ -52,7 +52,7 @@
          (results (cog-mine db-cpt
                             #:minsup ms
                             #:maximum-iterations mi
-                            #:incremental-expansion #t
+                            #:conjunction-expansion #t
                             #:max-conjuncts mc
                             #:max-variables mv
                             #:surprisingness 'nisurp))

--- a/examples/miner/simple/simple.scm
+++ b/examples/miner/simple/simple.scm
@@ -28,12 +28,12 @@
 ;; surprisingness of conjunctions of components)
 (define results-as (cog-mine (cog-atomspace)
                              #:minsup 2
-                             #:incremental-expansion #f
+                             #:conjunction-expansion #f
                              #:surprisingness 'none))
 
 ;; Call the miner on the database of interest instead, should yield
 ;; the same results.
 (define results-lst (cog-mine (list AB AC)
                               #:minsup 2
-                              #:incremental-expansion #f
+                              #:conjunction-expansion #f
                               #:surprisingness 'none))

--- a/examples/miner/sumo/README.md
+++ b/examples/miner/sumo/README.md
@@ -21,10 +21,10 @@ cd <EXTERNAL-TOOLS>/SUMO_importer
 ./sumo-opencog.sh
 ```
 
-copy the generated output (replace `<OPENCOG_REPO>` appropriately)
+copy the generated output (replace `<MINER_REPO>` appropriately)
 
 ```bash
-SCM_DIR=<OPENCOG_REPO>/examples/miner/sumo/scm
+SCM_DIR=<MINER_REPO>/examples/miner/sumo/scm
 mkdir "$SCM_DIR"
 cp all-sumo-labeled-kb.scm "$SCM_DIR"
 cp sumo/output/*.scm "$SCM_DIR"

--- a/examples/miner/sumo/mine-sumo.scm
+++ b/examples/miner/sumo/mine-sumo.scm
@@ -51,7 +51,7 @@
          (results (cog-mine db-cpt
                             #:minsup ms
                             #:maximum-iterations mi
-                            #:incremental-expansion #t
+                            #:conjunction-expansion #t
                             #:max-conjuncts mc
                             #:max-variables mv
                             #:surprisingness 'nisurp))

--- a/examples/miner/ugly-male-soda-drinker/ugly-male-soda-drinker.scm
+++ b/examples/miner/ugly-male-soda-drinker/ugly-male-soda-drinker.scm
@@ -67,7 +67,7 @@
 (define results (cog-mine (cog-atomspace)
                           #:minsup 5
                           #:maximum-iterations 100
-                          #:incremental-expansion #t
+                          #:conjunction-expansion #t
                           #:max-conjuncts 3
                           #:max-variables 2
                           #:surprisingness 'nisurp))

--- a/opencog/miner/MinerSCM.cc
+++ b/opencog/miner/MinerSCM.cc
@@ -93,10 +93,13 @@ protected:
 	 * Construct the conjunction of 2 patterns. If cnjtion is a
 	 * conjunction, then expand it with pattern. It is assumed that
 	 * pattern cannot be a conjunction itself.
+	 *
+	 * ms is the minimum support
+	 * mv is the maximum of variables
+	 * es is a flag to enforce specialization
 	 */
-	Handle do_expand_conjunction(Handle cnjtion, Handle pattern,
-	                             Handle db, Handle ms, Handle mv,
-	                             bool enforce_specialization);
+	Handle do_expand_conjunction(Handle cnjtion, Handle pattern, Handle db,
+	                             Handle ms, Handle mv, bool es);
 
 	/**
 	 * Calculate the I-Surprisingness of the pattern (and its
@@ -249,7 +252,7 @@ bool MinerSCM::do_enough_support(Handle pattern, Handle db, Handle ms_h)
 
 Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
                                        Handle db, Handle ms_h, Handle mv_h,
-                                       bool enforce_specialization)
+                                       bool es)
 {
 	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-expand-conjunction");
 
@@ -261,8 +264,7 @@ Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
 	unsigned mv = MinerUtils::get_uint(mv_h);
 
 	HandleSet results = MinerUtils::expand_conjunction(cnjtion, pattern,
-	                                                   db_seq, ms, mv,
-	                                                   enforce_specialization);
+	                                                   db_seq, ms, mv, es);
 	return as->add_link(SET_LINK, HandleSeq(results.begin(), results.end()));
 }
 

--- a/opencog/miner/MinerSCM.cc
+++ b/opencog/miner/MinerSCM.cc
@@ -95,7 +95,8 @@ protected:
 	 * pattern cannot be a conjunction itself.
 	 */
 	Handle do_expand_conjunction(Handle cnjtion, Handle pattern,
-	                             Handle db, Handle ms, Handle mv);
+	                             Handle db, Handle ms, Handle mv,
+	                             bool enforce_specialization);
 
 	/**
 	 * Calculate the I-Surprisingness of the pattern (and its
@@ -247,7 +248,8 @@ bool MinerSCM::do_enough_support(Handle pattern, Handle db, Handle ms_h)
 }
 
 Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
-                                       Handle db, Handle ms_h, Handle mv_h)
+                                       Handle db, Handle ms_h, Handle mv_h,
+                                       bool enforce_specialization)
 {
 	AtomSpace *as = SchemeSmob::ss_get_env_as("cog-expand-conjunction");
 
@@ -259,7 +261,8 @@ Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
 	unsigned mv = MinerUtils::get_uint(mv_h);
 
 	HandleSet results = MinerUtils::expand_conjunction(cnjtion, pattern,
-	                                                   db_seq, ms, mv);
+	                                                   db_seq, ms, mv,
+	                                                   enforce_specialization);
 	return as->add_link(SET_LINK, HandleSeq(results.begin(), results.end()));
 }
 

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -783,9 +783,11 @@ HandleSet MinerUtils::expand_conjunction_connect_rec(const Handle& cnjtion,
                                                      const HandleSeq& db,
                                                      unsigned ms,
                                                      unsigned mv,
+                                                     bool enforce_specialization,
                                                      const HandleMap& pv2cv,
                                                      unsigned pvi)
 {
+	// TODO: support enforce_specialization
 	HandleSet patterns;
 	const Variables& cvars = get_variables(cnjtion);
 	const Variables& pvars = get_variables(pattern);
@@ -818,6 +820,7 @@ HandleSet MinerUtils::expand_conjunction_connect_rec(const Handle& cnjtion,
 
 			HandleSet rrs = expand_conjunction_connect_rec(cnjtion, pattern,
 			                                               db, ms, mv,
+			                                               enforce_specialization,
 			                                               pv2cv_ext, pvi + 1);
 			patterns.insert(rrs.begin(), rrs.end());
 		}
@@ -829,14 +832,16 @@ HandleSet MinerUtils::expand_conjunction(const Handle& cnjtion,
                                          const Handle& pattern,
                                          const HandleSeq& db,
                                          unsigned ms,
-                                         unsigned mv)
+                                         unsigned mv,
+                                         bool enforce_specialization)
 {
 	// Alpha convert pattern, if necessary, to avoid collisions between
 	// cnjtion variables and pattern variables
 	Handle apat = alpha_convert(pattern, get_variables(cnjtion));
 
 	// Consider all variable mappings from apat to cnjtion
-	return expand_conjunction_connect_rec(cnjtion, apat, db, ms, mv);
+	return expand_conjunction_connect_rec(cnjtion, apat, db, ms, mv,
+	                                      enforce_specialization);
 }
 
 const Handle& MinerUtils::support_key()

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -783,11 +783,11 @@ HandleSet MinerUtils::expand_conjunction_connect_rec(const Handle& cnjtion,
                                                      const HandleSeq& db,
                                                      unsigned ms,
                                                      unsigned mv,
-                                                     bool enforce_specialization,
+                                                     bool es,
                                                      const HandleMap& pv2cv,
                                                      unsigned pvi)
 {
-	// TODO: support enforce_specialization
+	// TODO: support enforce specialization
 	HandleSet patterns;
 	const Variables& cvars = get_variables(cnjtion);
 	const Variables& pvars = get_variables(pattern);
@@ -818,9 +818,8 @@ HandleSet MinerUtils::expand_conjunction_connect_rec(const Handle& cnjtion,
 				patterns.insert(npat);
 			}
 
-			HandleSet rrs = expand_conjunction_connect_rec(cnjtion, pattern,
-			                                               db, ms, mv,
-			                                               enforce_specialization,
+			HandleSet rrs = expand_conjunction_connect_rec(cnjtion, pattern, db,
+			                                               ms, mv, es,
 			                                               pv2cv_ext, pvi + 1);
 			patterns.insert(rrs.begin(), rrs.end());
 		}
@@ -833,15 +832,14 @@ HandleSet MinerUtils::expand_conjunction(const Handle& cnjtion,
                                          const HandleSeq& db,
                                          unsigned ms,
                                          unsigned mv,
-                                         bool enforce_specialization)
+                                         bool es)
 {
 	// Alpha convert pattern, if necessary, to avoid collisions between
 	// cnjtion variables and pattern variables
 	Handle apat = alpha_convert(pattern, get_variables(cnjtion));
 
 	// Consider all variable mappings from apat to cnjtion
-	return expand_conjunction_connect_rec(cnjtion, apat, db, ms, mv,
-	                                      enforce_specialization);
+	return expand_conjunction_connect_rec(cnjtion, apat, db, ms, mv, es);
 }
 
 const Handle& MinerUtils::support_key()

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -463,6 +463,7 @@ public:
 	                                                const HandleSeq& db,
 	                                                unsigned ms,
 	                                                unsigned mv,
+	                                                bool enforce_specialization,
 	                                                const HandleMap& pv2cv=HandleMap(),
 	                                                unsigned pvi=0);
 
@@ -485,13 +486,17 @@ public:
 	 * If an expansion is cnjtion itself it will be dismissed.
 	 *
 	 * mv is the maximum number of variables allowed in the resulting
-	 * patterns.
+	 *    patterns.
+	 *
+	 * enforce_specialization is a flag to enforce specialization by
+	 *                        discarding new variables.
 	 */
 	static HandleSet expand_conjunction(const Handle& cnjtion,
 	                                    const Handle& pattern,
 	                                    const HandleSeq& db,
 	                                    unsigned ms,
-	                                    unsigned mv=UINT_MAX);
+	                                    unsigned mv=UINT_MAX,
+	                                    bool enforce_specialization=true);
 
 	/**
 	 * Return an atom to serve as key to store the support value.

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -463,7 +463,7 @@ public:
 	                                                const HandleSeq& db,
 	                                                unsigned ms,
 	                                                unsigned mv,
-	                                                bool enforce_specialization,
+	                                                bool es,
 	                                                const HandleMap& pv2cv=HandleMap(),
 	                                                unsigned pvi=0);
 
@@ -488,15 +488,15 @@ public:
 	 * mv is the maximum number of variables allowed in the resulting
 	 *    patterns.
 	 *
-	 * enforce_specialization is a flag to enforce specialization by
-	 *                        discarding new variables.
+	 * es is a flag to enforce specialization by
+	 *    discarding new variables.
 	 */
 	static HandleSet expand_conjunction(const Handle& cnjtion,
 	                                    const Handle& pattern,
 	                                    const HandleSeq& db,
 	                                    unsigned ms,
 	                                    unsigned mv=UINT_MAX,
-	                                    bool enforce_specialization=true);
+	                                    bool es=true);
 
 	/**
 	 * Return an atom to serve as key to store the support value.

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -253,7 +253,8 @@ public:
 
 	/**
 	 * Given a sequence of clause create a LambdaLink of it without
-	 * variable declaration, introducing an AndLink if necessary.
+	 * variable declaration, introducing a AndLink or PresentLink if
+	 * necessary.
 	 */
 	static Handle mk_pattern_no_vardecl(const HandleSeq& clauses);
 
@@ -453,19 +454,33 @@ public:
 	                                         const HandleMap& pv2cv);
 
 	/**
-	 * Like expand_conjunction_connect above but recursively consider
-	 * all variable mappings from pattern to cnjtion.
+	 * Like expand_conjunction_connect but recursively consider all
+	 * variable mappings from pattern to cnjtion.
 	 *
 	 * pvi is the variable index of pattern variable declaration.
 	 */
-	static HandleSet expand_conjunction_connect_rec(const Handle& cnjtion,
-	                                                const Handle& pattern,
-	                                                const HandleSeq& db,
-	                                                unsigned ms,
-	                                                unsigned mv,
-	                                                bool es,
-	                                                const HandleMap& pv2cv=HandleMap(),
-	                                                unsigned pvi=0);
+	static HandleSet expand_conjunction_rec(const Handle& cnjtion,
+	                                        const Handle& pattern,
+	                                        const HandleSeq& db,
+	                                        unsigned ms,
+	                                        unsigned mv,
+	                                        const HandleMap& pv2cv=HandleMap(),
+	                                        unsigned pvi=0);
+
+	/**
+	 * Like expand_conjunction_rec but enforce specialization. Mean
+	 * only total mappings from the variables of pattern to the
+	 * variables of cnjtion will be considered, as to not introduced
+	 * any new variables, for that reason mv can be ignored (cause
+	 * cnjtion and pattern are assumed to already have a number of
+	 * variables not exceeding mv).
+	 */
+	static HandleSet expand_conjunction_es_rec(const Handle& cnjtion,
+	                                           const Handle& pattern,
+	                                           const HandleSeq& db,
+	                                           unsigned ms,
+	                                           const HandleMap& pv2cv=HandleMap(),
+	                                           unsigned pvi=0);
 
 	/**
 	 * Given cnjtion and pattern, consider all possible connections

--- a/opencog/miner/miner-utils.scm
+++ b/opencog/miner/miner-utils.scm
@@ -214,11 +214,13 @@
 (define* (configure-rules pm-rbs
                           #:key
                           (conjunction-expansion #t)
+                          (enforce-specialization #t)
                           (max-conjuncts 3)
                           (max-variables 3))
   (configure-mandatory-rules pm-rbs)
   (configure-optional-rules pm-rbs
                             #:conjunction-expansion conjunction-expansion
+                            #:enforce-specialization enforce-specialization
                             #:max-conjuncts max-conjuncts
                             #:max-variables max-variables))
 

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -107,12 +107,16 @@ private:
 	Handle ure_pm(const AtomSpace& db_as, int minsup,
 	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
 	              bool conjunction_expansion=false,
-	              int max_conjuncts=-1,
+	              unsigned max_conjuncts=UINT_MAX,
+	              unsigned max_variables=UINT_MAX,
+	              bool enforce_specialization=true,
 	              double complexity_penalty=0.0);
 	Handle ure_pm(const HandleSeq& db, int minsup,
 	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
 	              bool conjunction_expansion=false,
-	              int max_conjuncts=-1,
+	              unsigned max_conjuncts=UINT_MAX,
+	              unsigned max_variables=UINT_MAX,
+	              bool enforce_specialization=true,
 	              double complexity_penalty=0.0);
 
 	/**
@@ -158,6 +162,7 @@ public:
 	void test_ABCD();
 	void test_ABAB();
 	void test_AAAA();
+	void test_transitivity();
 	void test_evaluation();
 	void test_2conjuncts_1();
 	void test_2conjuncts_2();
@@ -193,25 +198,31 @@ Handle MinerUTest::mk_nconjunct(unsigned n)
 Handle MinerUTest::ure_pm(const AtomSpace& db_as, int minsup,
                           int maximum_iterations, Handle initpat,
                           bool conjunction_expansion,
-                          int max_conjuncts,
+                          unsigned max_conjuncts,
+                          unsigned max_variables,
+                          bool enforce_specialization,
                           double complexity_penalty)
 {
 	return MinerUTestUtils::ure_pm(_as, _scm, pm_rb, db_as, minsup,
 	                               maximum_iterations, initpat,
-	                               conjunction_expansion, max_conjuncts,
-	                               complexity_penalty);
+	                               conjunction_expansion,
+	                               max_conjuncts, max_variables,
+	                               enforce_specialization, complexity_penalty);
 }
 
 Handle MinerUTest::ure_pm(const HandleSeq& db, int minsup,
                           int maximum_iterations, Handle initpat,
                           bool conjunction_expansion,
-                          int max_conjuncts,
+                          unsigned max_conjuncts,
+                          unsigned max_variables,
+                          bool enforce_specialization,
                           double complexity_penalty)
 {
 	return MinerUTestUtils::ure_pm(_as, _scm, pm_rb, db, minsup,
 	                               maximum_iterations, initpat,
-	                               conjunction_expansion, max_conjuncts,
-	                               complexity_penalty);
+	                               conjunction_expansion,
+	                               max_conjuncts, max_variables,
+	                               enforce_specialization, complexity_penalty);
 }
 
 HandleTree MinerUTest::cpp_pm(const AtomSpace& db_as,
@@ -237,13 +248,13 @@ MinerUTest::MinerUTest() : _scm(&_as), _tmp_scm(&_tmp_as)
 	randGen().seed(0);
 
 	// Main logger
-	logger().set_level(Logger::INFO);
+	logger().set_level(Logger::DEBUG);
 	logger().set_timestamp_flag(false);
 	logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::INFO);
+	ure_logger().set_level(Logger::DEBUG);
 	ure_logger().set_timestamp_flag(false);
 	ure_logger().set_sync_flag(true);
 	ure_logger().set_print_to_stdout_flag(true);
@@ -666,15 +677,15 @@ void MinerUTest::test_AB_AC()
 
 	// NEXT TODO: get rid of the C++ pattern miner, as it is not used at all
 
-	// Run C++ pattern miner (using _as for testing more diverse
-	// content)
-	HandleTree cpp_results = cpp_pm(_as, 2);
-	Handle cpp_expected = MinerUtils::mk_pattern(Y, {InhAY});
+	// // Run C++ pattern miner (using _as for testing more diverse
+	// // content)
+	// HandleTree cpp_results = cpp_pm(_as, 2);
+	// Handle cpp_expected = MinerUtils::mk_pattern(Y, {InhAY});
 
-	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
-	logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
+	// logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
+	// logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
 
-	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
+	// TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner (using _as for testing more diverse
 	// content)
@@ -899,6 +910,12 @@ void MinerUTest::test_AAAA()
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
 	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+}
+
+void MinerUTest::test_transitivity()
+{
+	// TODO: Mine transitivity pattern using incremental conjunction
+	// expansion. Check with and without enforce_specialization
 }
 
 void MinerUTest::test_evaluation()
@@ -1322,7 +1339,9 @@ void MinerUTest::test_SodaDrinker_incremental()
 
 	// Run URE pattern miner
 	bool conjunction_expansion = true;
-	int max_conjuncts = 3;
+	unsigned max_conjuncts = 3;
+	unsigned max_variables = UINT_MAX;
+	bool enforce_specialization = true;
 	double complexity_penalty = 1;
 	int minsup = 5;
 	int max_iteration = 100;
@@ -1330,6 +1349,8 @@ void MinerUTest::test_SodaDrinker_incremental()
 	                            initpat,
 	                            conjunction_expansion,
 	                            max_conjuncts,
+	                            max_variables,
+	                            enforce_specialization,
 	                            complexity_penalty);
 
 	// The pattern of interest looks like
@@ -1475,12 +1496,16 @@ void MinerUTest::test_vqa()
 	bool conjunction_expansion = true;
 	int minsup = 500;
 	int max_iteration = 20;
-	int max_conjuncts = 2;
+	unsigned max_conjuncts = 2;
+	unsigned max_variables = UINT_MAX;
+	bool enforce_specialization = false;
 	double complexity_penalty = 1;
 	Handle ure_results = ure_pm(_tmp_as, minsup, max_iteration,
 	                            initpat,
 	                            conjunction_expansion,
 	                            max_conjuncts,
+	                            max_variables,
+	                            enforce_specialization,
 	                            complexity_penalty),
 		ure_expected = mk_minsup_eval(minsup, expected);
 

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -106,12 +106,12 @@ private:
 	 */
 	Handle ure_pm(const AtomSpace& db_as, int minsup,
 	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
-	              bool incremental_expansion=false,
+	              bool conjunction_expansion=false,
 	              int max_conjuncts=-1,
 	              double complexity_penalty=0.0);
 	Handle ure_pm(const HandleSeq& db, int minsup,
 	              int max_iter=-1, Handle initpat=Handle::UNDEFINED,
-	              bool incremental_expansion=false,
+	              bool conjunction_expansion=false,
 	              int max_conjuncts=-1,
 	              double complexity_penalty=0.0);
 
@@ -192,25 +192,25 @@ Handle MinerUTest::mk_nconjunct(unsigned n)
 
 Handle MinerUTest::ure_pm(const AtomSpace& db_as, int minsup,
                           int maximum_iterations, Handle initpat,
-                          bool incremental_expansion,
+                          bool conjunction_expansion,
                           int max_conjuncts,
                           double complexity_penalty)
 {
 	return MinerUTestUtils::ure_pm(_as, _scm, pm_rb, db_as, minsup,
 	                               maximum_iterations, initpat,
-	                               incremental_expansion, max_conjuncts,
+	                               conjunction_expansion, max_conjuncts,
 	                               complexity_penalty);
 }
 
 Handle MinerUTest::ure_pm(const HandleSeq& db, int minsup,
                           int maximum_iterations, Handle initpat,
-                          bool incremental_expansion,
+                          bool conjunction_expansion,
                           int max_conjuncts,
                           double complexity_penalty)
 {
 	return MinerUTestUtils::ure_pm(_as, _scm, pm_rb, db, minsup,
 	                               maximum_iterations, initpat,
-	                               incremental_expansion, max_conjuncts,
+	                               conjunction_expansion, max_conjuncts,
 	                               complexity_penalty);
 }
 
@@ -1321,14 +1321,14 @@ void MinerUTest::test_SodaDrinker_incremental()
 	// bug (the pattern is ignored by surprisingness).
 
 	// Run URE pattern miner
-	bool incremental_expansion = true;
+	bool conjunction_expansion = true;
 	int max_conjuncts = 3;
 	double complexity_penalty = 1;
 	int minsup = 5;
 	int max_iteration = 100;
 	Handle ure_results = ure_pm(_tmp_as, minsup, max_iteration,
 	                            initpat,
-	                            incremental_expansion,
+	                            conjunction_expansion,
 	                            max_conjuncts,
 	                            complexity_penalty);
 
@@ -1472,14 +1472,14 @@ void MinerUTest::test_vqa()
 	logger().debug() << "expected = " << oc_to_string(expected);
 
 	// Run URE pattern miner
-	bool incremental_expansion = true;
+	bool conjunction_expansion = true;
 	int minsup = 500;
 	int max_iteration = 20;
 	int max_conjuncts = 2;
 	double complexity_penalty = 1;
 	Handle ure_results = ure_pm(_tmp_as, minsup, max_iteration,
 	                            initpat,
-	                            incremental_expansion,
+	                            conjunction_expansion,
 	                            max_conjuncts,
 	                            complexity_penalty),
 		ure_expected = mk_minsup_eval(minsup, expected);

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -163,6 +163,7 @@ public:
 	void test_ABAB();
 	void test_AAAA();
 	void test_transitivity();
+	void test_no_transitivity();
 	void test_evaluation();
 	void test_2conjuncts_1();
 	void test_2conjuncts_2();
@@ -248,16 +249,16 @@ MinerUTest::MinerUTest() : _scm(&_as), _tmp_scm(&_tmp_as)
 	randGen().seed(0);
 
 	// Main logger
-	logger().set_level(Logger::DEBUG);
+	logger().set_level(Logger::INFO);
 	logger().set_timestamp_flag(false);
-	logger().set_sync_flag(true);
+	// logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
 
 	// URE logger
-	ure_logger().set_level(Logger::DEBUG);
+	ure_logger().set_level(Logger::INFO);
 	ure_logger().set_timestamp_flag(false);
-	ure_logger().set_sync_flag(true);
-	ure_logger().set_print_to_stdout_flag(true);
+	// ure_logger().set_sync_flag(true);
+	// ure_logger().set_print_to_stdout_flag(false);
 
 	// Configure scheme load-paths that are common for all tests.
 	_scm.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR
@@ -494,7 +495,8 @@ void MinerUTest::test_expand_conjunction_3()
 		VarXY = al(VARIABLE_LIST, X, Y),
 		pat = MinerUtils::mk_pattern(VarXY, {InhXY});
 
-	HandleSet results = MinerUtils::expand_conjunction(pat, pat, db, 1);
+	HandleSet results = MinerUtils::expand_conjunction(pat, pat, db, 1,
+	                                                   UINT_MAX, false);
 	Handle
 		InhXW = al(INHERITANCE_LINK, X, W),
 		InhZX = al(INHERITANCE_LINK, Z, X),
@@ -512,6 +514,12 @@ void MinerUTest::test_expand_conjunction_3()
 	logger().debug() << "expected = " << oc_to_string(expected);
 
 	TS_ASSERT(content_eq(results, expected));
+
+	// Same as above but enforce specialization
+	HandleSet es_results = MinerUtils::expand_conjunction(pat, pat, db, 1,
+	                                                      UINT_MAX, true);
+	HandleSet es_expected{};
+	TS_ASSERT(content_eq(es_results, es_expected));
 }
 
 void MinerUTest::test_expand_conjunction_4()
@@ -534,7 +542,8 @@ void MinerUTest::test_expand_conjunction_4()
 		        VarXY,
 		        LstXY);
 
-	HandleSet results = MinerUtils::expand_conjunction(p1, p2, db, 1);
+	HandleSet results = MinerUtils::expand_conjunction(p1, p2, db, 1,
+	                                                   UINT_MAX, false);
 	Handle
 		InhXZ = al(INHERITANCE_LINK, X, Z),
 		InhZY = al(INHERITANCE_LINK, Z, Y),
@@ -901,10 +910,11 @@ void MinerUTest::test_AAAA()
 
 	// Run URE pattern miner
 	Handle ure_results = ure_pm(db, 2, 50, initpat),
+		ure_body = al(IMPLICATION_LINK,
+		              InhXX,
+		              InhXX),
 		ure_expected = mk_minsup_eval(2,
-		                              MinerUtils::mk_pattern_no_vardecl({al(IMPLICATION_LINK,
-		                                                                    InhXX,
-		                                                                    InhXX)}));
+		                              MinerUtils::mk_pattern_no_vardecl({ure_body}));
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
@@ -914,8 +924,54 @@ void MinerUTest::test_AAAA()
 
 void MinerUTest::test_transitivity()
 {
-	// TODO: Mine transitivity pattern using incremental conjunction
-	// expansion. Check with and without enforce_specialization
+	// Mine transitivity pattern using incremental conjunction
+	// expansion. Check with and without enforce specialization.
+
+	// Define db
+	Handle
+		InhAB = al(INHERITANCE_LINK, A, B),
+		InhBC = al(INHERITANCE_LINK, B, C);
+	HandleSeq db{InhAB, InhBC};
+
+	// Run URE pattern miner without enforcing specialization (which is
+	// necessary to mine transitivity).
+	int ms = 1;
+	Handle results = ure_pm(db, ms, 50, top, true, 2, 3, false);
+	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
+	                     al(INHERITANCE_LINK, Y, Z)};
+	Handle expected = mk_minsup_eval(ms,
+	                                 MinerUtils::mk_pattern_no_vardecl(clauses));
+
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
+}
+
+void MinerUTest::test_no_transitivity()
+{
+	// Like test_transitivity but enforce specialization, thus should
+	// miss the transitivity pattern.
+
+	// Define db
+	Handle
+		InhAB = al(INHERITANCE_LINK, A, B),
+		InhBC = al(INHERITANCE_LINK, B, C);
+	HandleSeq db{InhAB, InhBC};
+
+	// Run URE pattern miner without enforcing specialization (which is
+	// necessary to mine transitivity).
+	int ms = 1;
+	Handle results = ure_pm(db, ms, 50, top, true, 2, 3, true);
+	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
+	                     al(INHERITANCE_LINK, Y, Z)};
+	Handle not_expect = mk_minsup_eval(ms,
+	                                   MinerUtils::mk_pattern_no_vardecl(clauses));
+
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "not_expect = " << oc_to_string(not_expect);
+
+	TS_ASSERT(not is_in(not_expect, results->getOutgoingSet()));
 }
 
 void MinerUTest::test_evaluation()
@@ -1382,11 +1438,7 @@ void MinerUTest::test_SodaDrinker_incremental()
 	std::string mode("nisurp-old");
 	HandleSeq surp_results = MinerUTestUtils::ure_surp(_as, _scm, surp_rb,
 	                                                   mode, max_conjuncts);
-
-	// We get the second, because due to the old I-Surprisingness not
-	// accounting for linkage, the ugly male soda drinker comes second
-	// not first.
-	Handle surp_result = surp_results[1];
+	Handle surp_result = surp_results.front();
 
 	logger().debug() << "surp_results = " << oc_to_string(surp_results);
 

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -146,13 +146,16 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                Handle initpat,
                                bool conjunction_expansion,
                                unsigned max_conjuncts,
+                               unsigned max_variables,
+                               bool enforce_specialization,
                                double complexity_penalty)
 {
 	HandleSeq db;
 	db_as.get_handles_by_type(std::inserter(db, db.end()),
 	                          opencog::ATOM, true);
 	return ure_pm(as, scm, pm_rb, db, minsup, maximum_iterations, initpat,
-	              conjunction_expansion, max_conjuncts, complexity_penalty);
+	              conjunction_expansion, max_conjuncts, max_variables,
+	              enforce_specialization, complexity_penalty);
 }
 
 Handle MinerUTestUtils::ure_pm(AtomSpace& as,
@@ -164,6 +167,8 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                Handle initpat,
                                bool conjunction_expansion,
                                unsigned max_conjuncts,
+                               unsigned max_variables,
+                               bool enforce_specialization,
                                double complexity_penalty)
 {
 	// Make (Member dt (Concept "db)) links
@@ -183,7 +188,8 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 		return al(SET_LINK);
 
 	// Add incremental conjunction expansion if necessary
-	configure_optional_rules(scm, conjunction_expansion, max_conjuncts);
+	configure_optional_rules(scm, conjunction_expansion, max_conjuncts,
+	                         max_variables, enforce_specialization);
 
 	// Otherwise prepare the source
 	TruthValuePtr tv = TruthValue::TRUE_TV();
@@ -287,7 +293,8 @@ void MinerUTestUtils::configure_mandatory_rules(SchemeEval& scm)
 void MinerUTestUtils::configure_optional_rules(SchemeEval& scm,
                                                bool conjunction_expansion,
                                                unsigned max_conjuncts,
-                                               unsigned max_variables)
+                                               unsigned max_variables,
+                                               bool enforce_specialization)
 {
 	std::string call = "(configure-optional-rules (Concept \"pm-rbs\")";
 	call += " #:conjunction-expansion #";
@@ -296,6 +303,8 @@ void MinerUTestUtils::configure_optional_rules(SchemeEval& scm,
 	call += std::to_string(max_conjuncts);
 	call += " #:max-variables ";
 	call += std::to_string(max_variables);
+	call += " #:enforce-specialization ";
+	call += enforce_specialization ? "#t" : "#f";
 	call += ")";
 	std::string rs = scm.eval(call);
 	logger().debug() << "MinerUTest::configure_optional_rules() rs = " << rs;

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -144,7 +144,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                int minsup,
                                int maximum_iterations,
                                Handle initpat,
-                               bool incremental_expansion,
+                               bool conjunction_expansion,
                                unsigned max_conjuncts,
                                double complexity_penalty)
 {
@@ -152,7 +152,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 	db_as.get_handles_by_type(std::inserter(db, db.end()),
 	                          opencog::ATOM, true);
 	return ure_pm(as, scm, pm_rb, db, minsup, maximum_iterations, initpat,
-	              incremental_expansion, max_conjuncts, complexity_penalty);
+	              conjunction_expansion, max_conjuncts, complexity_penalty);
 }
 
 Handle MinerUTestUtils::ure_pm(AtomSpace& as,
@@ -162,7 +162,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                int minsup,
                                int maximum_iterations,
                                Handle initpat,
-                               bool incremental_expansion,
+                               bool conjunction_expansion,
                                unsigned max_conjuncts,
                                double complexity_penalty)
 {
@@ -183,7 +183,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 		return al(SET_LINK);
 
 	// Add incremental conjunction expansion if necessary
-	configure_optional_rules(scm, incremental_expansion, max_conjuncts);
+	configure_optional_rules(scm, conjunction_expansion, max_conjuncts);
 
 	// Otherwise prepare the source
 	TruthValuePtr tv = TruthValue::TRUE_TV();
@@ -192,7 +192,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 	// Run the forward chainer from the initial pattern
 	ForwardChainer fc(as, pm_rb, source);
 	fc.get_config().set_maximum_iterations(maximum_iterations);
-	fc.get_config().set_retry_exhausted_sources(incremental_expansion);
+	fc.get_config().set_retry_exhausted_sources(conjunction_expansion);
 	fc.get_config().set_complexity_penalty(complexity_penalty);
 	fc.do_chain();
 
@@ -285,13 +285,13 @@ void MinerUTestUtils::configure_mandatory_rules(SchemeEval& scm)
 }
 
 void MinerUTestUtils::configure_optional_rules(SchemeEval& scm,
-                                               bool incremental_expansion,
+                                               bool conjunction_expansion,
                                                unsigned max_conjuncts,
                                                unsigned max_variables)
 {
 	std::string call = "(configure-optional-rules (Concept \"pm-rbs\")";
-	call += " #:incremental-expansion #";
-	call += incremental_expansion ? "t" : "f";
+	call += " #:conjunction-expansion #";
+	call += conjunction_expansion ? "t" : "f";
 	call += " #:max-conjuncts ";
 	call += std::to_string(max_conjuncts);
 	call += " #:max-variables ";

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -180,6 +180,8 @@ public:
 	                     Handle initpat=Handle::UNDEFINED,
 	                     bool conjunction_expansion=false,
 	                     unsigned max_conjuncts=UINT_MAX,
+	                     unsigned max_variables=UINT_MAX,
+	                     bool enforce_specialization=true,
 	                     double complexity_penalty=0.0);
 	static Handle ure_pm(AtomSpace& as,
 	                     SchemeEval& scm,
@@ -189,6 +191,8 @@ public:
 	                     Handle initpat=Handle::UNDEFINED,
 	                     bool conjunction_expansion=false,
 	                     unsigned max_conjuncts=UINT_MAX,
+	                     unsigned max_variables=UINT_MAX,
+	                     bool enforce_specialization=true,
 	                     double complexity_penalty=0.0);
 
 	/**
@@ -274,7 +278,8 @@ public:
 	static void configure_optional_rules(SchemeEval& scm,
 	                                     bool conjunction_expansion,
 	                                     unsigned max_conjuncts=UINT_MAX,
-	                                     unsigned max_variables=UINT_MAX);
+	                                     unsigned max_variables=UINT_MAX,
+	                                     bool enforce_specialization=false);
 	static void configure_surprisingness(SchemeEval& scm,
 	                                     const Handle& surp_rb,
 	                                     const std::string& mode,

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -178,7 +178,7 @@ public:
 	                     int minsup,
 	                     int max_iter=-1,
 	                     Handle initpat=Handle::UNDEFINED,
-	                     bool incremental_expansion=false,
+	                     bool conjunction_expansion=false,
 	                     unsigned max_conjuncts=UINT_MAX,
 	                     double complexity_penalty=0.0);
 	static Handle ure_pm(AtomSpace& as,
@@ -187,7 +187,7 @@ public:
 	                     const HandleSeq& db, int minsup,
 	                     int max_iter=-1,
 	                     Handle initpat=Handle::UNDEFINED,
-	                     bool incremental_expansion=false,
+	                     bool conjunction_expansion=false,
 	                     unsigned max_conjuncts=UINT_MAX,
 	                     double complexity_penalty=0.0);
 
@@ -272,7 +272,7 @@ public:
 
 	static void configure_mandatory_rules(SchemeEval& scm);
 	static void configure_optional_rules(SchemeEval& scm,
-	                                     bool incremental_expansion,
+	                                     bool conjunction_expansion,
 	                                     unsigned max_conjuncts=UINT_MAX,
 	                                     unsigned max_variables=UINT_MAX);
 	static void configure_surprisingness(SchemeEval& scm,


### PR DESCRIPTION
* Add `#:enforce-specialization` option to forbid conjunction expansion to create abstractions. This eliminates patterns introducing new variables. When this option is enabled (which is the default) it speeds up the search, however some patterns such as transitivity are dismissed as they require introducing new variables.
* The option `#:incremental-expansion` has been renamed `#:conjunction-expansion` as it is more specific.