### PR TITLE
Add conjunction expansion max variables option

### DIFF
--- a/examples/miner/ugly-male-soda-drinker/ugly-male-soda-drinker.scm
+++ b/examples/miner/ugly-male-soda-drinker/ugly-male-soda-drinker.scm
@@ -7,10 +7,10 @@
 ;; (cog-logger-set-level! "debug")
 ;; (cog-logger-set-sync! #t)
 ;; (cog-logger-set-timestamp! #f)
-;; (use-modules (opencog ure))
-;; (ure-logger-set-level! "debug")
+(use-modules (opencog ure))
+(ure-logger-set-level! "debug")
 ;; (ure-logger-set-sync! #t)
-;; (ure-logger-set-timestamp! #f)
+(ure-logger-set-timestamp! #f)
 
 ;; Load KB
 (load "kb.scm")
@@ -70,4 +70,5 @@
                           #:conjunction-expansion #t
                           #:max-conjuncts 3
                           #:max-variables 2
+                          #:max-cnjexp-variables 1
                           #:surprisingness 'nisurp))

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -51,7 +51,8 @@
 namespace opencog
 {
 
-HandleSetSeq MinerUtils::shallow_abstract(const Valuations& valuations, unsigned ms)
+HandleSetSeq MinerUtils::shallow_abstract(const Valuations& valuations,
+                                          unsigned ms)
 {
 	// Base case
 	if (valuations.no_focus())
@@ -66,7 +67,8 @@ HandleSetSeq MinerUtils::shallow_abstract(const Valuations& valuations, unsigned
 	return shabs_per_var;
 }
 
-HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations, unsigned ms)
+HandleSet MinerUtils::focus_shallow_abstract(const Valuations& valuations,
+                                             unsigned ms)
 {
 	HandleSet shabs;
 
@@ -826,6 +828,7 @@ HandleSet MinerUtils::expand_conjunction_es_rec(const Handle& cnjtion,
                                                 const Handle& pattern,
                                                 const HandleSeq& db,
                                                 unsigned ms,
+                                                unsigned mv,
                                                 const HandleMap& pv2cv,
                                                 unsigned pvi)
 {
@@ -840,9 +843,10 @@ HandleSet MinerUtils::expand_conjunction_es_rec(const Handle& cnjtion,
 	if (pv2cv.size() == pvars.size()) {
 		Handle npat = expand_conjunction_connect(cnjtion, pattern, pv2cv);
 
-		// If the number of conjuncts has dropped then it shouldn't be
-		// considered.
-		if (n_conjuncts(npat) <= n_conjuncts(cnjtion))
+		// If the number of variables is too high or the number of
+		// conjuncts has dropped then it shouldn't be considered.
+		if (mv < get_variables(npat).size() or
+		    n_conjuncts(npat) <= n_conjuncts(cnjtion))
 			return {};
 
 		// Insert npat in the atomspace where cnjtion and pattern
@@ -868,7 +872,7 @@ HandleSet MinerUtils::expand_conjunction_es_rec(const Handle& cnjtion,
 		HandleMap pv2cv_ext(pv2cv);
 		pv2cv_ext[pvars.varseq[pvi]] = cv;
 		HandleSet rrs = expand_conjunction_es_rec(cnjtion, pattern, db, ms,
-		                                          pv2cv_ext, pvi + 1);
+		                                          mv, pv2cv_ext, pvi + 1);
 		patterns.insert(rrs.begin(), rrs.end());
 	}
 	return patterns;
@@ -887,7 +891,7 @@ HandleSet MinerUtils::expand_conjunction(const Handle& cnjtion,
 
 	// Consider all variable mappings from apat to cnjtion
 	return es ?
-		expand_conjunction_es_rec(cnjtion, apat, db, ms)
+		expand_conjunction_es_rec(cnjtion, apat, db, ms, mv)
 		: expand_conjunction_rec(cnjtion, apat, db, ms, mv);
 }
 

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -471,14 +471,13 @@ public:
 	 * Like expand_conjunction_rec but enforce specialization. Mean
 	 * only total mappings from the variables of pattern to the
 	 * variables of cnjtion will be considered, as to not introduced
-	 * any new variables, for that reason mv can be ignored (cause
-	 * cnjtion and pattern are assumed to already have a number of
-	 * variables not exceeding mv).
+	 * any new variables.
 	 */
 	static HandleSet expand_conjunction_es_rec(const Handle& cnjtion,
 	                                           const Handle& pattern,
 	                                           const HandleSeq& db,
 	                                           unsigned ms,
+	                                           unsigned mv,
 	                                           const HandleMap& pv2cv=HandleMap(),
 	                                           unsigned pvi=0);
 

--- a/opencog/miner/miner-utils.scm
+++ b/opencog/miner/miner-utils.scm
@@ -170,8 +170,8 @@
                                                conjunction-expansion
                                                enforce-specialization
                                                max-conjuncts
-                                               max-variables)
-  (define mv (min 9 max-variables))
+                                               max-cnjexp-variables)
+  (define mv (min 9 max-cnjexp-variables))
 
   (if (and conjunction-expansion (< 1 max-conjuncts))
       ;; (load-from-path (mk-full-rule-path "conjunction-expansion.scm"))
@@ -209,7 +209,8 @@
                                    (conjunction-expansion #t)
                                    (enforce-specialization #t)
                                    (max-conjuncts 3)
-                                   (max-variables 3))
+                                   (max-variables 3)
+                                   (max-cnjexp-variables 2))
 
   ;; Load shallow specialization, either unary, if
   ;; conjunction-expansion is enabled, or not
@@ -222,20 +223,22 @@
                                          conjunction-expansion
                                          enforce-specialization
                                          max-conjuncts
-                                         max-variables))
+                                         (min max-variables max-cnjexp-variables)))
 
 (define* (configure-rules pm-rbs
                           #:key
                           (conjunction-expansion #t)
                           (enforce-specialization #t)
                           (max-conjuncts 3)
-                          (max-variables 3))
+                          (max-variables 3)
+                          (max-cnjexp-variables 2))
   (configure-mandatory-rules pm-rbs)
   (configure-optional-rules pm-rbs
                             #:conjunction-expansion conjunction-expansion
                             #:enforce-specialization enforce-specialization
                             #:max-conjuncts max-conjuncts
-                            #:max-variables max-variables))
+                            #:max-variables max-variables
+                            #:max-cnjexp-variables max-cnjexp-variables))
 
 (define* (configure-surprisingness surp-rbs mode max-conjuncts)
   ;; Add surprisingness rules
@@ -282,7 +285,8 @@
                           (conjunction-expansion #t)
                           (enforce-specialization #t)
                           (max-conjuncts 3)
-                          (max-variables 3))
+                          (max-variables 3)
+                          (max-cnjexp-variables 2))
 "
   Given a Concept node representing a rule based system for the
   pattern miner. Automatically configure it with the appropriate
@@ -294,7 +298,8 @@
                           #:conjunction-expansion ce
                           #:enforce-specialization es
                           #:max-conjuncts mc)
-                          #:max-variables mv)
+                          #:max-variables mv
+                          #:max-cnjexp-variables mcev)
 
   pm-rbs: Concept node of the rule-based system to configure
 
@@ -326,13 +331,17 @@
   mv: [optional, default=3] Maximum number of variables that the resulting
       patterns should contain. As of now mv cannot be set above 9 (which
       should be more than enough).
+
+  mcev: [optional, default=2] Maximum number of variables in patterns produced
+        by the conjunction expansion rule.
 "
   ;; Load and associate rules to pm-rbs
   (configure-rules pm-rbs
                    #:conjunction-expansion conjunction-expansion
                    #:enforce-specialization enforce-specialization
                    #:max-conjuncts max-conjuncts
-                   #:max-variables max-variables)
+                   #:max-variables max-variables
+                   #:max-cnjexp-variables max-cnjexp-variables)
 
   ;; Set parameters
   (ure-set-maximum-iterations pm-rbs maximum-iterations)
@@ -495,6 +504,7 @@
                    (enforce-specialization #t)
                    (max-conjuncts 3)
                    (max-variables 3)
+                   (max-cnjexp-variables 2)
                    (surprisingness 'isurp))
 "
   Mine patterns in db (data trees, a.k.a. grounded hypergraphs) with minimum
@@ -511,6 +521,7 @@
                    #:enforce-specializtion es
                    #:max-conjuncts mc
                    #:max-variables mv
+                   #:max-cnjexp-variables mcev
                    #:surprisingness su)
 
   db: Collection of data trees to mine. It can be given in 3 forms
@@ -581,6 +592,9 @@
   mv: [optional, default=3] Maximum number of variables that the resulting
       patterns can contain. As of now mv cannot be set above 9 (which
       should be more than enough).
+
+  mcev: [optional, default=2] Maximum number of variables in patterns produced
+        by the conjunction expansion rule.
 
   su: [optional, default='isurp] After running the pattern miner,
       patterns can be ranked according to some surprisingness measure.
@@ -665,7 +679,8 @@
                                        #:conjunction-expansion conjunction-expansion
                                        #:enforce-specialization enforce-specialization
                                        #:max-conjuncts max-conjuncts
-                                       #:max-variables max-variables))
+                                       #:max-variables max-variables
+                                       #:max-cnjexp-variables max-cnjexp-variables))
 
                ;; Run pattern miner in a forward way
                (results (cog-fc miner-rbs source))

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -109,6 +109,7 @@ private:
 	              bool conjunction_expansion=false,
 	              unsigned max_conjuncts=UINT_MAX,
 	              unsigned max_variables=UINT_MAX,
+	              unsigned max_cnjexp_variables=UINT_MAX,
 	              bool enforce_specialization=true,
 	              double complexity_penalty=0.0);
 	Handle ure_pm(const HandleSeq& db, int minsup,
@@ -116,6 +117,7 @@ private:
 	              bool conjunction_expansion=false,
 	              unsigned max_conjuncts=UINT_MAX,
 	              unsigned max_variables=UINT_MAX,
+	              unsigned max_cnjexp_variables=UINT_MAX,
 	              bool enforce_specialization=true,
 	              double complexity_penalty=0.0);
 
@@ -201,6 +203,7 @@ Handle MinerUTest::ure_pm(const AtomSpace& db_as, int minsup,
                           bool conjunction_expansion,
                           unsigned max_conjuncts,
                           unsigned max_variables,
+                          unsigned max_cnjexp_variables,
                           bool enforce_specialization,
                           double complexity_penalty)
 {
@@ -208,6 +211,7 @@ Handle MinerUTest::ure_pm(const AtomSpace& db_as, int minsup,
 	                               maximum_iterations, initpat,
 	                               conjunction_expansion,
 	                               max_conjuncts, max_variables,
+	                               max_cnjexp_variables,
 	                               enforce_specialization, complexity_penalty);
 }
 
@@ -216,6 +220,7 @@ Handle MinerUTest::ure_pm(const HandleSeq& db, int minsup,
                           bool conjunction_expansion,
                           unsigned max_conjuncts,
                           unsigned max_variables,
+                          unsigned max_cnjexp_variables,
                           bool enforce_specialization,
                           double complexity_penalty)
 {
@@ -223,6 +228,7 @@ Handle MinerUTest::ure_pm(const HandleSeq& db, int minsup,
 	                               maximum_iterations, initpat,
 	                               conjunction_expansion,
 	                               max_conjuncts, max_variables,
+	                               max_cnjexp_variables,
 	                               enforce_specialization, complexity_penalty);
 }
 
@@ -936,7 +942,7 @@ void MinerUTest::test_transitivity()
 	// Run URE pattern miner without enforcing specialization (which is
 	// necessary to mine transitivity).
 	int ms = 1;
-	Handle results = ure_pm(db, ms, 50, top, true, 2, 3, false);
+	Handle results = ure_pm(db, ms, 50, top, true, 2, 3, 3, false);
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Y, Z)};
 	Handle expected = mk_minsup_eval(ms,
@@ -962,7 +968,7 @@ void MinerUTest::test_no_transitivity()
 	// Run URE pattern miner without enforcing specialization (which is
 	// necessary to mine transitivity).
 	int ms = 1;
-	Handle results = ure_pm(db, ms, 50, top, true, 2, 3, true);
+	Handle results = ure_pm(db, ms, 50, top, true, 2, 3, 3, true);
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Y, Z)};
 	Handle not_expect = mk_minsup_eval(ms,
@@ -1396,7 +1402,8 @@ void MinerUTest::test_SodaDrinker_incremental()
 	// Run URE pattern miner
 	bool conjunction_expansion = true;
 	unsigned max_conjuncts = 3;
-	unsigned max_variables = UINT_MAX;
+	unsigned max_variables = 2;
+	unsigned max_cnjexp_variables = 1;
 	bool enforce_specialization = true;
 	double complexity_penalty = 1;
 	int minsup = 5;
@@ -1406,6 +1413,7 @@ void MinerUTest::test_SodaDrinker_incremental()
 	                            conjunction_expansion,
 	                            max_conjuncts,
 	                            max_variables,
+	                            max_cnjexp_variables,
 	                            enforce_specialization,
 	                            complexity_penalty);
 
@@ -1550,6 +1558,7 @@ void MinerUTest::test_vqa()
 	int max_iteration = 20;
 	unsigned max_conjuncts = 2;
 	unsigned max_variables = UINT_MAX;
+	unsigned max_cnjexp_variables = UINT_MAX;
 	bool enforce_specialization = false;
 	double complexity_penalty = 1;
 	Handle ure_results = ure_pm(_tmp_as, minsup, max_iteration,
@@ -1557,6 +1566,7 @@ void MinerUTest::test_vqa()
 	                            conjunction_expansion,
 	                            max_conjuncts,
 	                            max_variables,
+	                            max_cnjexp_variables,
 	                            enforce_specialization,
 	                            complexity_penalty),
 		ure_expected = mk_minsup_eval(minsup, expected);

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -147,6 +147,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                bool conjunction_expansion,
                                unsigned max_conjuncts,
                                unsigned max_variables,
+                               unsigned max_cnjexp_variables,
                                bool enforce_specialization,
                                double complexity_penalty)
 {
@@ -155,6 +156,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 	                          opencog::ATOM, true);
 	return ure_pm(as, scm, pm_rb, db, minsup, maximum_iterations, initpat,
 	              conjunction_expansion, max_conjuncts, max_variables,
+	              max_cnjexp_variables,
 	              enforce_specialization, complexity_penalty);
 }
 
@@ -168,6 +170,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                bool conjunction_expansion,
                                unsigned max_conjuncts,
                                unsigned max_variables,
+                               unsigned max_cnjexp_variables,
                                bool enforce_specialization,
                                double complexity_penalty)
 {
@@ -189,7 +192,8 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 
 	// Add incremental conjunction expansion if necessary
 	configure_optional_rules(scm, conjunction_expansion, max_conjuncts,
-	                         max_variables, enforce_specialization);
+	                         max_variables, max_cnjexp_variables,
+	                         enforce_specialization);
 
 	// Otherwise prepare the source
 	TruthValuePtr tv = TruthValue::TRUE_TV();
@@ -294,6 +298,7 @@ void MinerUTestUtils::configure_optional_rules(SchemeEval& scm,
                                                bool conjunction_expansion,
                                                unsigned max_conjuncts,
                                                unsigned max_variables,
+                                               unsigned max_cnjexp_variables,
                                                bool enforce_specialization)
 {
 	std::string call = "(configure-optional-rules (Concept \"pm-rbs\")";
@@ -303,6 +308,8 @@ void MinerUTestUtils::configure_optional_rules(SchemeEval& scm,
 	call += std::to_string(max_conjuncts);
 	call += " #:max-variables ";
 	call += std::to_string(max_variables);
+	call += " #:max-cnjexp-variables ";
+	call += std::to_string(max_cnjexp_variables);
 	call += " #:enforce-specialization ";
 	call += enforce_specialization ? "#t" : "#f";
 	call += ")";

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -181,6 +181,7 @@ public:
 	                     bool conjunction_expansion=false,
 	                     unsigned max_conjuncts=UINT_MAX,
 	                     unsigned max_variables=UINT_MAX,
+	                     unsigned max_cnjexp_variables=UINT_MAX,
 	                     bool enforce_specialization=true,
 	                     double complexity_penalty=0.0);
 	static Handle ure_pm(AtomSpace& as,
@@ -192,6 +193,7 @@ public:
 	                     bool conjunction_expansion=false,
 	                     unsigned max_conjuncts=UINT_MAX,
 	                     unsigned max_variables=UINT_MAX,
+	                     unsigned max_cnjexp_variables=UINT_MAX,
 	                     bool enforce_specialization=true,
 	                     double complexity_penalty=0.0);
 
@@ -279,6 +281,7 @@ public:
 	                                     bool conjunction_expansion,
 	                                     unsigned max_conjuncts=UINT_MAX,
 	                                     unsigned max_variables=UINT_MAX,
+	                                     unsigned max_cnjexp_variables=UINT_MAX,
 	                                     bool enforce_specialization=false);
 	static void configure_surprisingness(SchemeEval& scm,
 	                                     const Handle& surp_rb,


### PR DESCRIPTION
To independently control how many variables the conjunction expansion rule outputs, as extra variables during that step tend to be both costly and confusing for the user.