### PR TITLE
Improve custom reduct for pattern miner (remove abstract clauses)

### DIFF
--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -638,7 +638,7 @@ void MinerUtils::remove_useless_clauses(const Handle& vardecl, HandleSeq& clause
 {
 	remove_constant_clauses(vardecl, clauses);
 	remove_redundant_subclauses(clauses);
-	// TODO: add remove_abstract_clauses(vardecl, clauses);
+	remove_abstract_clauses(vardecl, clauses);
 }
 
 void MinerUtils::remove_constant_clauses(const Handle& vardecl, HandleSeq& clauses)
@@ -677,6 +677,19 @@ void MinerUtils::remove_redundant_clauses(HandleSeq& clauses)
 	boost::erase(clauses,
 	             boost::unique<boost::return_found_end, HandleSeq, HandleEqual>
 	             (clauses, HandleEqual()));
+}
+
+void MinerUtils::remove_abstract_clauses(const Handle& vardecl,
+                                         HandleSeq& clauses)
+{
+	// TODO
+}
+
+bool MinerUtils::no_new_variables(const Handle& clause,
+                                  const HandleSeq& clauses)
+{
+	// TODO
+	return false;
 }
 
 Handle MinerUtils::alpha_convert(const Handle& pattern,

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -455,7 +455,8 @@ Handle MinerUtils::mk_pattern_filtering_vardecl(const Handle& vardecl,
 Handle MinerUtils::mk_pattern(const Handle& vardecl,
                               const HandleSeq& clauses)
 {
-	return Handle(createLambdaLink(vardecl, mk_body(clauses)));
+	Handle body = mk_body(clauses);
+	return body ? Handle(createLambdaLink(vardecl, body)) : Handle::UNDEFINED;
 }
 
 HandleSeq MinerUtils::get_component_patterns(const Handle& pattern)
@@ -638,7 +639,7 @@ void MinerUtils::remove_useless_clauses(const Handle& vardecl, HandleSeq& clause
 {
 	remove_constant_clauses(vardecl, clauses);
 	remove_redundant_subclauses(clauses);
-	remove_abstract_clauses(vardecl, clauses);
+	remove_abstract_clauses(clauses);
 }
 
 void MinerUtils::remove_constant_clauses(const Handle& vardecl, HandleSeq& clauses)
@@ -657,17 +658,8 @@ void MinerUtils::remove_redundant_subclauses(HandleSeq& clauses)
 {
 	// Check that each clause is not a subtree of another clause,
 	// remove it otherwise.
-	for (auto it = clauses.begin(); it != clauses.end();) {
-		// Take all clauses except *it
-		HandleSeq others(clauses.begin(), it);
-		others.insert(others.end(), std::next(it), clauses.end());
-
-		// Make sure *it is not a subtree of any other
-		if (is_unquoted_unscoped_in_any_tree(others, *it))
-			it = clauses.erase(it);
-		else
-			++it;
-	}
+	remove_if(clauses, [](const Handle& clause, const HandleSeq& others) {
+			return is_unquoted_unscoped_in_any_tree(others, clause); });
 }
 
 void MinerUtils::remove_redundant_clauses(HandleSeq& clauses)
@@ -679,31 +671,33 @@ void MinerUtils::remove_redundant_clauses(HandleSeq& clauses)
 	             (clauses, HandleEqual()));
 }
 
-void MinerUtils::remove_abstract_clauses(const Handle& vardecl,
-                                         HandleSeq& clauses)
+void MinerUtils::remove_abstract_clauses(HandleSeq& clauses)
 {
-	// TODO
+	// For each clause, for each variable of that clause, check whether
+	// such clause is an abstraction of all other clauses where such
+	// variable appears, if so, then it can be removed.
+	remove_if(clauses, &MinerUtils::is_more_abstract_foreach_var);
 }
 
-bool MinerUtils::no_new_variables(const Handle& clause,
-                                  const HandleSeq& clauses)
+bool MinerUtils::has_only_joint_variables(const Handle& clause,
+                                          const HandleSeq& clauses)
 {
-	// TODO
+	// TODO: See Surprisingness::joint_variables for help.
 	return false;
 }
 
-bool MinerUtils::is_syntax_more_abstract(const HandleSeq& l_blk,
-                                         const HandleSeq& r_blk,
-                                         const Handle& var)
+bool MinerUtils::is_blk_syntax_more_abstract(const HandleSeq& l_blk,
+                                             const HandleSeq& r_blk,
+                                             const Handle& var)
 {
 	Handle l_pat = MinerUtils::mk_pattern_no_vardecl(l_blk);
 	Handle r_pat = MinerUtils::mk_pattern_no_vardecl(r_blk);
-	return is_syntax_more_abstract(l_pat, r_pat, var);
+	return is_pat_syntax_more_abstract(l_pat, r_pat, var);
 }
 
-bool MinerUtils::is_syntax_more_abstract(const Handle& l_pat,
-                                         const Handle& r_pat,
-                                         const Handle& var)
+bool MinerUtils::is_pat_syntax_more_abstract(const Handle& l_pat,
+                                             const Handle& r_pat,
+                                             const Handle& var)
 {
 	Variables l_vars = MinerUtils::get_variables(l_pat);
 	Variables r_vars = MinerUtils::get_variables(r_pat);
@@ -719,7 +713,10 @@ bool MinerUtils::is_syntax_more_abstract(const Handle& l_pat,
 	l_vars.erase(var);
 	r_vars.erase(var);
 
-	// Find all mappings from variables (except var) to terms
+	// Find all mappings from variables (except var) to terms.
+	//
+	// TODO: maybe this can be optimized by using matching instead of
+	// unification.
 	Unify unify(l_body, r_body, l_vars, r_vars);
 	Unify::SolutionSet sol = unify();
 
@@ -732,38 +729,64 @@ bool MinerUtils::is_syntax_more_abstract(const Handle& l_pat,
 	Unify::TypedSubstitutions tsub = unify.typed_substitutions(sol, r_body);
 
 	// Check that for all mappings no variable in r_vars maps to a
-	// value (non-variable).
+	// value (non-variable) or var (which is viewed as value here).
 	for (const auto& var2val_map : tsub)
 		for (const auto& var_val : var2val_map.first)
-			if (is_value(var_val, r_vars))
+			if (is_value(var_val, r_vars, var))
 				return false;
 	return true;
 }
 
-bool MinerUtils::is_more_abstract(const Handle& l_pat,
-                                  const Handle& r_pat,
-                                  const Handle& var)
+bool MinerUtils::is_pat_more_abstract(const Handle& l_pat,
+                                      const Handle& r_pat,
+                                      const Handle& var)
 {
 	HandleSeq l_clauses = MinerUtils::get_clauses(l_pat);
 	HandleSeq r_clauses = MinerUtils::get_clauses(r_pat);
 	HandleSeq l_scs = connected_subpattern_with_var(l_clauses, var);
 	HandleSeq r_scs = connected_subpattern_with_var(r_clauses, var);
-	return is_more_abstract(l_scs, r_scs, var);
+	return is_blk_more_abstract(l_scs, r_scs, var);
 }
 
-bool MinerUtils::is_more_abstract(const HandleSeq& l_blk,
-                                  const HandleSeq& r_blk,
-                                  const Handle& var)
+bool MinerUtils::is_blk_more_abstract(const HandleSeq& l_blk,
+                                      const HandleSeq& r_blk,
+                                      const Handle& var)
 {
 	using namespace boost::algorithm;
 	HandleSeqSeq rps = powerseq_without_empty(r_blk);
 	return any_of(partitions(l_blk), [&](const HandleSeqSeq& lp) {
 			return any_of(rps, [&](const HandleSeq& rs) {
 					return all_of(lp, [&](const HandleSeq& lb) {
-							return is_syntax_more_abstract(lb, rs, var);
+							return is_blk_syntax_more_abstract(lb, rs, var);
 						});
 				});
 		});
+}
+
+bool MinerUtils::is_more_abstract_foreach_var(const Handle& clause,
+                                              const HandleSeq& others)
+{
+	HandleSet vars = get_free_variables(clause);
+	for (const Handle& var : vars) {
+		// Filter in all other clauses containing var
+		HandleSeq ov;
+		for (const Handle& other : others)
+			if (is_free_in_tree(other, var))
+				ov.push_back(other);
+
+		// If var appears nowhere in others, then return false, because
+		// it means such pattern brings something about that variable
+		// that no other pattern brings, thus cannot be an abstraction.
+		if (ov.empty())
+			return false;
+
+		// Check if clause is an abstraction of each clause in ov
+		// relative to var
+		if (not boost::algorithm::all_of(ov, [&](const Handle& other) {
+					return is_blk_syntax_more_abstract({clause}, {other}, var); }))
+			return false;
+	}
+	return true;
 }
 
 HandleSeqSeq MinerUtils::powerseq_without_empty(const HandleSeq& blk)
@@ -809,10 +832,12 @@ Handle MinerUtils::alpha_convert(const Handle& pattern,
 }
 
 bool MinerUtils::is_value(const Unify::HandleCHandleMap::value_type& var_val,
-                          const Variables& vars)
+                          const Variables& vars,
+                          const Handle& var)
 {
 	return vars.is_in_varset(var_val.first)
-		and not var_val.second.is_free_variable();
+		and (var_val.second == Unify::CHandle(var)
+		     or not var_val.second.is_free_variable());
 }
 
 HandleSeqSeq MinerUtils::connected_subpatterns_with_var(
@@ -959,14 +984,15 @@ Handle MinerUtils::expand_conjunction_connect(const Handle& cnjtion,
 	HandleSeq nclauses = get_clauses(cnjtion_body);
 	append(nclauses, get_clauses_of_body(npat_body));
 
-	// Remove redundant subclauses. This can happen if there's only one
-	// variable to connect, then some subclause turn out to be
-	// redundant.
-	remove_redundant_subclauses(nclauses);
+	// get new variable declaration
+	Handle nvardecl = cnjtion_vars.get_vardecl();
+
+	// Remove useless clauses, such as constant, redundant or abstract
+	// clauses.
+	remove_useless_clauses(nvardecl, nclauses);
 
 	// Recreate expanded conjunction
-	Handle nvardecl = cnjtion_vars.get_vardecl(),
-		npattern = mk_pattern(nvardecl, nclauses);
+	Handle npattern = mk_pattern(nvardecl, nclauses);
 
 	return npattern;
 }
@@ -1116,6 +1142,22 @@ double MinerUtils::support_mem(const Handle& pattern,
 		set_support(pattern, sup);
 	}
 	return sup;
+}
+
+void MinerUtils::remove_if(HandleSeq& clauses,
+                           std::function<bool(const Handle&, const HandleSeq&)> fun)
+{
+	for (auto it = clauses.begin(); it != clauses.end();) {
+		// Take all clauses except *it
+		HandleSeq others(clauses.begin(), it);
+		others.insert(others.end(), std::next(it), clauses.end());
+
+		// Remove if fun is true
+		if (fun(*it, others))
+			it = clauses.erase(it);
+		else
+			++it;
+	}
 }
 
 std::string oc_to_string(const HandleSeqSeqSeq& hsss,

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -638,6 +638,7 @@ void MinerUtils::remove_useless_clauses(const Handle& vardecl, HandleSeq& clause
 {
 	remove_constant_clauses(vardecl, clauses);
 	remove_redundant_subclauses(clauses);
+	// TODO: add remove_abstract_clauses(vardecl, clauses);
 }
 
 void MinerUtils::remove_constant_clauses(const Handle& vardecl, HandleSeq& clauses)

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -412,6 +412,38 @@ public:
 	static void remove_redundant_clauses(HandleSeq& clauses);
 
 	/**
+	 * Remove clauses that are more abstract than all other clauses,
+	 * thus should not change the semantics of the pattern.
+	 *
+	 * For instance given the clauses
+	 *
+	 *     (Inheritance (Variable "$X") (Concept "pet"))
+	 *     (Inheritance (Concept "cat") (Variable "$Y"))
+	 *     (Inheritance (Variable "$X") (Variable "$Y")))
+	 *
+	 * the last one is more abstract than either of the first 2, thus
+	 * can be removed.
+	 */
+	static void remove_abstract_clauses(const Handle& vardecl,
+	                                    HandleSeq& clauses);
+
+	/**
+	 * Return true iff clause does not introduce new variables already
+	 * in clauses.
+	 *
+	 * For instance given
+	 *
+	 * clause = (Inheritance (Variable "$X") (Variable "$Y"))
+	 *
+	 * clauses = { (Inheritance (Variable "$X") (Concept "pet"))
+	 *             (Inheritance (Concept "cat") (Variable "$Y")) }
+	 *
+	 * all variables in clause appear in clauses so it returns true.
+	 */
+	static bool no_new_variables(const Handle& clause,
+	                             const HandleSeq& clauses);
+
+	/**
 	 * Alpha convert pattern so that none of its variables collide with
 	 * the variables in other_vars.
 	 */

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -23,12 +23,19 @@
 #ifndef OPENCOG_MINER_UTILS_H_
 #define OPENCOG_MINER_UTILS_H_
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Handle.h>
+#include <opencog/unify/Unify.h>
+
+#include <boost/algorithm/cxx11/all_of.hpp>
+#include <boost/algorithm/cxx11/any_of.hpp>
 
 #include "Valuations.h"
 
 namespace opencog
 {
+
+typedef std::vector<HandleSeqSeq> HandleSeqSeqSeq;
 
 /**
  * Collection of static methods for the pattern miner.
@@ -444,11 +451,194 @@ public:
 	                             const HandleSeq& clauses);
 
 	/**
+	 * Tell whether the left block/subpattern is is syntactically more
+	 * abstract than the right block/subpattern relative to a given
+	 * variable.
+	 *
+	 * For instance
+	 *
+	 * l_blk = { List X Y Z }
+	 * r_blk = { List W A Z }
+	 *
+	 * l_blk is more abstract than r_blk relative to Z because the
+	 * matching values of Z in l_blk is a subset of the matching values
+	 * of Z in l_blk.
+	 */
+	static bool is_syntax_more_abstract(const HandleSeq& l_blk,
+	                                    const HandleSeq& r_blk,
+	                                    const Handle& var);
+
+	/**
+	 * List above but takes scope links instead of blocks (whether each
+	 * scope link has the conjunction of clauses of its block as body).
+	 *
+	 * TODO: for now, this code relies on unification. However it can
+	 * certainly be optimized by not relying on unification and being
+	 * re-implemented instead, and perhaps it could then be merged to
+	 * the unification code.
+	 */
+	static bool is_syntax_more_abstract(const Handle& l_pat,
+	                                    const Handle& r_pat,
+	                                    const Handle& var);
+
+	/**
+	 * Like is_syntax_more_abstract but takes into account a bit of
+	 * semantics as well (though none that requires data), in
+	 * particular it handles conjunctions of clauses such that l_pat is
+	 * more abstract if there exists a partition lp of l_pat (meaning a
+	 * partition of conjunctions of clauses in l_pat) such that there
+	 * exists a subset rs of r_pat (meaning a subset of clauses of
+	 * r_pat) such that rs is a syntactic specialization, relative to
+	 * var, of each block lb of lp.
+	 *
+	 * For instance
+	 *
+	 * l_pat = Lambda
+	 *           X Y Z
+	 *           And
+	 *             Inheritance
+	 *               X
+	 *               Z
+	 *             Inheritance
+	 *               Y
+	 *               Z
+	 *
+	 * r_pat = Lambda
+	 *           Z
+	 *           Inheritance
+	 *             A
+	 *             Z
+	 *
+	 * var = Z
+	 *
+	 * l_pat is indeed an abstraction of r_pat because there exists a
+	 * partition lp = { {Inheritance X Z}, {Inheritance Y Z} } such
+	 * that the subset { Inheritance A Z} is a syntactic specialization
+	 * of each block of lp.
+	 */
+	static bool is_more_abstract(const Handle& l_pat,
+	                             const Handle& r_pat,
+	                             const Handle& var);
+
+	/**
+	 * Like above but consider list of clauses instead of patterns.
+	 */
+	static bool is_more_abstract(const HandleSeq& l_blk,
+	                             const HandleSeq& r_blk,
+	                             const Handle& var);
+
+	/**
+	 * Like powerset but return a sequence of sequences instead of set
+	 * of sets. Discard the empty sequence.
+	 */
+	static HandleSeqSeq powerseq_without_empty(const HandleSeq& blk);
+
+
+	/**
 	 * Alpha convert pattern so that none of its variables collide with
 	 * the variables in other_vars.
 	 */
 	static Handle alpha_convert(const Handle& pattern,
 	                            const Variables& other_vars);
+
+	/**
+	 * Return true iff var_val is a pair with the first element a
+	 * variable in vars, and the second element a value (non-variable).
+	 */
+	static bool is_value(const Unify::HandleCHandleMap::value_type& var_val,
+	                     const Variables& vars);
+
+	/**
+	 * Copy all subpatterns/blocks where var appears. Also remove all
+	 * parts of the subpatterns that are not strongly connected with to
+	 * it relative to var.
+	 *
+	 * So for instance
+	 *
+	 * partition = { { Inheritance X Y, Inheritance Z A},
+	 *               { Inheritance X B, Inheritance Z Y} }
+	 *
+	 * var = Y
+	 *
+	 * returns
+	 *
+	 * { {Inheritance Z Y } }
+	 *
+	 * because
+	 *
+	 * 1. Y only appears in the second block
+	 *
+	 * 2. within that block
+	 *
+	 *    Inheritance X B
+	 *
+	 *    is not strongly connected to the component where Y appears.
+	 *
+	 * Ignoring non-strongly connected components allows to speed up
+	 * Surprisingness::value_count as well as covering more cases in
+	 * is_more_abstract.
+	 */
+	static HandleSeqSeq connected_subpatterns_with_var(const HandleSeqSeq& partition,
+	                                                   const Handle& var);
+	static HandleSeq connected_subpattern_with_var(const HandleSeq& blk,
+	                                               const Handle& var);
+
+	/**
+	 * Given a handle h and a sequence of sequences of handles, insert
+	 * h in front of each subsequence, duplicating each sequence with
+	 * its augmented subsequence. For instance
+	 *
+	 * h = D
+	 * hss = [[A],[B,C]]
+	 *
+	 * returns
+	 *
+	 * [[[D,A],[B,C]],[[A],[D,B,C]],[[A],[B,C],[D]]]
+	 */
+	static HandleSeqSeqSeq combinatorial_insert(const Handle& h,
+	                                            const HandleSeqSeq& hss);
+	static HandleSeqSeqSeq combinatorial_insert(const Handle& h,
+	                                            HandleSeqSeq::const_iterator from,
+	                                            HandleSeqSeq::const_iterator to);
+
+	/**
+	 * Given a HandleSeq hs, produce all partitions of hs. For instance
+	 * if hs is the following
+	 *
+	 * c = [A,B,C]
+	 *
+	 * return
+	 *
+	 * [[[A],[C],[B]],
+	 *  [[C,A],[B]],
+	 *  [[C],[B,A]],
+	 *  [[A],[C,B]],
+	 *  [[C,B,A]]]
+	 */
+	static HandleSeqSeqSeq partitions(const HandleSeq& hs);
+	static HandleSeqSeqSeq partitions(HandleSeq::const_iterator from,
+	                                  HandleSeq::const_iterator to);
+
+	/**
+	 * Like partitions but takes a pattern. Also the partition block
+	 * corresponding to the full set has been removed (since it is
+	 * already the block corresponding to the full pattern). For
+	 * instance
+	 *
+	 * pattern = Lambda
+	 *             And
+	 *               A
+	 *               B
+	 *               C
+	 *
+	 * return
+	 *
+	 * [[[A],[C],[B]],
+	 *  [[C,A],[B]],
+	 *  [[C],[B,A]],
+	 *  [[A],[C,B]]]
+	 */
+	static HandleSeqSeqSeq partitions_without_pattern(const Handle& pattern);
 
 	/**
 	 * Construct the conjunction of 2 patterns. If cnjtion is a
@@ -574,6 +764,13 @@ public:
 	                          const HandleSeq& db,
 	                          unsigned ms);
 };
+
+/**
+ * Given a partition, that is a sequence of blocks, where each
+ * block is a sequence of handles, return
+ */
+std::string oc_to_string(const HandleSeqSeqSeq& hsss,
+                         const std::string& indent=empty_string);
 
 } // ~namespace opencog
 

--- a/opencog/miner/Surprisingness.cc
+++ b/opencog/miner/Surprisingness.cc
@@ -527,7 +527,7 @@ bool Surprisingness::is_strictly_more_abstract(const HandleSeq& l_blk,
                                                const Handle& var)
 {
 	return not is_equivalent(l_blk, r_blk, var)
-		and MinerUtils::is_more_abstract(l_blk, r_blk, var);
+		and MinerUtils::is_blk_more_abstract(l_blk, r_blk, var);
 }
 
 void Surprisingness::rank_by_abstraction(HandleSeqSeq& partition, const Handle& var)
@@ -569,7 +569,9 @@ double Surprisingness::eq_prob(const HandleSeqSeq& partition,
 			// specialized abstraction.
 			int i = j-1;
 			while (0 <= i)
-				if (MinerUtils::is_more_abstract(var_partition[i], var_partition[j], var))
+				if (MinerUtils::is_blk_more_abstract(var_partition[i],
+				                                     var_partition[j],
+				                                     var))
 					break;
 				else i--;
 

--- a/opencog/miner/Surprisingness.cc
+++ b/opencog/miner/Surprisingness.cc
@@ -582,30 +582,6 @@ bool Surprisingness::is_equivalent(const Handle& l_pat,
 	return content_eq(l_pat, r_pat) and has_same_index(l_pat, r_pat, var);
 }
 
-HandleSeqUCounter::const_iterator Surprisingness::find_equivalent(
-	const HandleSeqUCounter& partition_c,
-	const HandleSeq& block,
-	const Handle& var)
-{
-	auto it = partition_c.begin();
-	for (; it != partition_c.end(); it++)
-		if (is_equivalent(it->first, block, var))
-			return it;
-	return it;
-}
-
-HandleSeqUCounter::iterator Surprisingness::find_equivalent(
-	HandleSeqUCounter& partition_c,
-	const HandleSeq& block,
-	const Handle& var)
-{
-	auto it = partition_c.begin();
-	for (; it != partition_c.end(); it++)
-		if (is_equivalent(it->first, block, var))
-			return it;
-	return it;
-}
-
 bool Surprisingness::is_syntax_more_abstract(const HandleSeq& l_blk,
                                              const HandleSeq& r_blk,
                                              const Handle& var)
@@ -740,23 +716,6 @@ HandleSeq Surprisingness::connected_subpattern_with_var(const HandleSeq& blk,
 		if (is_free_in_any_tree(scc, var))
 			return scc;
 	return {};
-}
-
-HandleSeqUCounter Surprisingness::group_eq(const HandleSeqSeq& partition,
-                                           const Handle& var)
-{
-	HandleSeqUCounter partition_c;
-	for (const HandleSeq& blk : partition) {
-		if (is_free_in_any_tree(blk, var)) {
-			auto it = find_equivalent(partition_c, blk, var);
-			if (it == partition_c.end()) {
-				partition_c[blk] = 1;
-			} else {
-				it->second++;
-			}
-		}
-	}
-	return partition_c;
 }
 
 double Surprisingness::eq_prob(const HandleSeqSeq& partition,

--- a/opencog/miner/Surprisingness.cc
+++ b/opencog/miner/Surprisingness.cc
@@ -29,7 +29,6 @@
 #include <opencog/util/random.h>
 #include <opencog/util/dorepeat.h>
 #include <opencog/util/algorithm.h>
-#include <opencog/util/empty_string.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
@@ -42,8 +41,6 @@
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/algorithm/min_element.hpp>
 #include <boost/range/algorithm/sort.hpp>
-#include <boost/algorithm/cxx11/all_of.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/math/special_functions/binomial.hpp>
 
@@ -80,7 +77,7 @@ double Surprisingness::isurp_old(const Handle& pattern,
 		return boost::accumulate(partition | boost::adaptors::transformed(blk_prob),
 		                         1.0, std::multiplies<double>());
 	};
-	HandleSeqSeqSeq prtns = partitions_without_pattern(pattern);
+	HandleSeqSeqSeq prtns = MinerUtils::partitions_without_pattern(pattern);
 	std::vector<double> estimates(prtns.size());
 	boost::transform(prtns, estimates.begin(), iprob);
 	auto p = std::minmax_element(estimates.begin(), estimates.end());
@@ -99,7 +96,8 @@ double Surprisingness::isurp(const Handle& pattern,
 	// independent assumption of between each partition block, taking
 	// into account the linkage probability.
 	std::vector<double> estimates;
-	for (const HandleSeqSeq& partition : partitions_without_pattern(pattern)) {
+	HandleSeqSeqSeq prtns = MinerUtils::partitions_without_pattern(pattern);
+	for (const HandleSeqSeq& partition : prtns) {
 		double jip = ji_prob_est(partition, pattern, db);
 		estimates.push_back(jip);
 	}
@@ -119,65 +117,6 @@ double Surprisingness::isurp(const Handle& pattern,
 double Surprisingness::dst_from_interval(double l, double u, double v)
 {
 	return (u < v ? v - u : (v < l ? l - v : 0.0));
-}
-
-HandleSeqSeqSeq Surprisingness::combinatorial_insert(const Handle& h,
-                                                     const HandleSeqSeq& hss)
-{
-	return combinatorial_insert(h, hss.begin(), hss.end());
-}
-
-HandleSeqSeqSeq Surprisingness::combinatorial_insert(const Handle& h,
-                                                     HandleSeqSeq::const_iterator from,
-                                                     HandleSeqSeq::const_iterator to)
-{
-	// Base case
-	if (from == to)
-		return {{{h}}};
-
-	// Recursive case
-	HandleSeq head = *from;       // Copy because will get modified
-	HandleSeqSeqSeq rst;
-	for (auto x : combinatorial_insert(h, ++from, to)) {
-		x.push_back(head);
-		rst.push_back(x);
-	}
-	head.push_back(h);
-	HandleSeqSeq fst(from, to);
-	fst.push_back(head);
-	rst.push_back(fst);
-	return rst; 
-}
-
-HandleSeqSeqSeq Surprisingness::partitions(const HandleSeq& hs)
-{
-	return partitions(hs.begin(), hs.end());
-}
-
-HandleSeqSeqSeq Surprisingness::partitions(HandleSeq::const_iterator from,
-                                           HandleSeq::const_iterator to)
-{
-	// Base case
-	if (from == to)
-		return {{}};
-
-	// Recursive case
-	Handle head = *from;
-	HandleSeqSeqSeq res;
-	for (const HandleSeqSeq& partition : partitions(++from, to)) {
-		HandleSeqSeqSeq subparts = combinatorial_insert(head, partition);
-		res.insert(res.end(), subparts.begin(), subparts.end());
-	}
-	return res;
-}
-
-HandleSeqSeqSeq Surprisingness::partitions_without_pattern(const Handle& pattern)
-{
-	HandleSeqSeqSeq prtns = partitions(MinerUtils::get_clauses(pattern));
-	prtns.resize(prtns.size() - 1);
-	// prtns.resize(1); // comment this output to only consider
-   //                  // singleton blocks (convenient for debugging)
-	return prtns;
 }
 
 Handle Surprisingness::add_pattern(const HandleSeq& block, AtomSpace& as)
@@ -535,7 +474,8 @@ TruthValuePtr Surprisingness::ji_tv_est(const Handle& pattern,
 	// independent assumption of between each partition block, taking
 	// into account the linkage probability.
 	TruthValueSeq etvs;
-	for (const HandleSeqSeq& partition : partitions_without_pattern(pattern)) {
+	HandleSeqSeqSeq prtns = MinerUtils::partitions_without_pattern(pattern);
+	for (const HandleSeqSeq& partition : prtns) {
 		TruthValuePtr etv = ji_tv_est(partition, pattern, db);
 		etvs.push_back(etv);
 	}
@@ -582,103 +522,12 @@ bool Surprisingness::is_equivalent(const Handle& l_pat,
 	return content_eq(l_pat, r_pat) and has_same_index(l_pat, r_pat, var);
 }
 
-bool Surprisingness::is_syntax_more_abstract(const HandleSeq& l_blk,
-                                             const HandleSeq& r_blk,
-                                             const Handle& var)
-{
-	Handle l_pat = MinerUtils::mk_pattern_no_vardecl(l_blk);
-	Handle r_pat = MinerUtils::mk_pattern_no_vardecl(r_blk);
-	return is_syntax_more_abstract(l_pat, r_pat, var);
-}
-
-bool Surprisingness::is_syntax_more_abstract(const Handle& l_pat,
-                                             const Handle& r_pat,
-                                             const Handle& var)
-{
-	Variables l_vars = MinerUtils::get_variables(l_pat);
-	Variables r_vars = MinerUtils::get_variables(r_pat);
-	Handle l_body = MinerUtils::get_body(l_pat);
-	Handle r_body = MinerUtils::get_body(r_pat);
-
-	// Let's first make sure that var is both in l_pat and r_pat
-	if (not l_vars.is_in_varset(var) or not r_vars.is_in_varset(var))
-		return false;
-
-	// Remove var from l_vars and r_vars to be considered as value
-	// rather than variable.
-	l_vars.erase(var);
-	r_vars.erase(var);
-
-	// Find all mappings from variables (except var) to terms
-	Unify unify(l_body, r_body, l_vars, r_vars);
-	Unify::SolutionSet sol = unify();
-
-	// If it is not satisfiable, l_pat is not an abstraction
-	//
-	// TODO: case of nary conjunctions additional care is needed
-	if (not sol.is_satisfiable())
-		return false;
-
-	Unify::TypedSubstitutions tsub = unify.typed_substitutions(sol, r_body);
-
-	// Check that for all mappings no variable in r_vars maps to a
-	// value (non-variable).
-	for (const auto& var2val_map : tsub)
-		for (const auto& var_val : var2val_map.first)
-			if (is_value(var_val, r_vars))
-				return false;
-	return true;
-}
-
-bool Surprisingness::is_more_abstract(const Handle& l_pat,
-                                      const Handle& r_pat,
-                                      const Handle& var)
-{
-	HandleSeq l_clauses = MinerUtils::get_clauses(l_pat);
-	HandleSeq r_clauses = MinerUtils::get_clauses(r_pat);
-	HandleSeq l_scs = connected_subpattern_with_var(l_clauses, var);
-	HandleSeq r_scs = connected_subpattern_with_var(r_clauses, var);
-	return is_more_abstract(l_scs, r_scs, var);
-}
-
-bool Surprisingness::is_more_abstract(const HandleSeq& l_blk,
-                                      const HandleSeq& r_blk,
-                                      const Handle& var)
-{
-	using namespace boost::algorithm;
-	HandleSeqSeq rps = powerseq_without_empty(r_blk);
-	return any_of(partitions(l_blk), [&](const HandleSeqSeq& lp) {
-			return any_of(rps, [&](const HandleSeq& rs) {
-					return all_of(lp, [&](const HandleSeq& lb) {
-							return is_syntax_more_abstract(lb, rs, var);
-						});
-				});
-		});
-}
-
-HandleSeqSeq Surprisingness::powerseq_without_empty(const HandleSeq& blk)
-{
-	HandleSetSet pset = powerset(HandleSet(blk.begin(), blk.end()));
-	HandleSeqSeq pseq;
-	for (const HandleSet& set : pset)
-		if (not set.empty())
-			pseq.push_back(HandleSeq(set.begin(), set.end()));
-	return pseq;
-}
-
 bool Surprisingness::is_strictly_more_abstract(const HandleSeq& l_blk,
                                                const HandleSeq& r_blk,
                                                const Handle& var)
 {
 	return not is_equivalent(l_blk, r_blk, var)
-		and is_more_abstract(l_blk, r_blk, var);
-}
-
-bool Surprisingness::is_value(const Unify::HandleCHandleMap::value_type& var_val,
-                              const Variables& vars)
-{
-	return vars.is_in_varset(var_val.first)
-		and not var_val.second.is_free_variable();
+		and MinerUtils::is_more_abstract(l_blk, r_blk, var);
 }
 
 void Surprisingness::rank_by_abstraction(HandleSeqSeq& partition, const Handle& var)
@@ -691,33 +540,6 @@ void Surprisingness::rank_by_abstraction(HandleSeqSeq& partition, const Handle& 
 	            });
 }
 
-HandleSeqSeq Surprisingness::connected_subpatterns_with_var(
-	const HandleSeqSeq& partition,
-	const Handle& var)
-{
-	HandleSeqSeq var_partition;
-	for (const HandleSeq& blk : partition) {
-		HandleSeq sc_blk = connected_subpattern_with_var(blk, var);
-		if (not sc_blk.empty()) {
-			var_partition.push_back(sc_blk);
-		}
-	}
-	return var_partition;
-}
-
-HandleSeq Surprisingness::connected_subpattern_with_var(const HandleSeq& blk,
-                                                        const Handle& var)
-{
-	if (not is_free_in_any_tree(blk, var))
-		return {};
-
-	HandleSeqSeq sccs = MinerUtils::get_components(blk);
-	for (const HandleSeq& scc : sccs)
-		if (is_free_in_any_tree(scc, var))
-			return scc;
-	return {};
-}
-
 double Surprisingness::eq_prob(const HandleSeqSeq& partition,
                                const Handle& pattern,
                                const HandleSeq& db)
@@ -728,7 +550,8 @@ double Surprisingness::eq_prob(const HandleSeqSeq& partition,
 	for (const Handle& var : joint_variables(pattern, partition)) {
 
 		// Select all strongly connected subpatterns containing var
-		HandleSeqSeq var_partition = connected_subpatterns_with_var(partition, var);
+		HandleSeqSeq var_partition =
+			MinerUtils::connected_subpatterns_with_var(partition, var);
 
 		// For each variable, sort the partition so that abstract
 		// blocks, relative to var, appear first.
@@ -746,7 +569,7 @@ double Surprisingness::eq_prob(const HandleSeqSeq& partition,
 			// specialized abstraction.
 			int i = j-1;
 			while (0 <= i)
-				if (is_more_abstract(var_partition[i], var_partition[j], var))
+				if (MinerUtils::is_more_abstract(var_partition[i], var_partition[j], var))
 					break;
 				else i--;
 
@@ -916,19 +739,6 @@ void Surprisingness::log_pdf(const BetaDistribution& bd, int bins)
 	logger().debug() << "Then use the following gnuplot commands to plot it:" << std::endl
 	                 << "set datafile separator comma" << std::endl
 	                 << "plot 'pdf.csv' using 1:2;";
-}
-
-std::string oc_to_string(const HandleSeqSeqSeq& hsss, const std::string& indent)
-{
-	std::stringstream ss;
-	ss << indent << "size = " << hsss.size() << std::endl;
-	size_t i = 0;
-	for (const HandleSeqSeq& hss : hsss) {
-		ss << indent << "atoms sets[" << i << "]:" << std::endl
-		   << oc_to_string(hss, indent + oc_to_string_indent);
-		i++;
-	}
-	return ss.str();
 }
 
 } // namespace opencog

--- a/opencog/miner/Surprisingness.h
+++ b/opencog/miner/Surprisingness.h
@@ -864,48 +864,16 @@ public:
 	                                               const Handle& var);
 
 	/**
-	 * Given subpatterns linked by a variable, count how many
-	 * subpatterns are equivalent with respect to this variable.
-	 *
-	 * For instance given patterns
-	 *
-	 * A = Inh X Y
-	 * B = Inh Y Z
-	 * C = Inh W Y
-	 *
-	 * A and C are equivalent with respect to Y, because all values
-	 * associated to Y in A and the same associated to Y in C, however
-	 * B is independent (occupies another block) because values
-	 * associated to Y in B are different than the values associated to
-	 * Y in A or C.
-	 *
-	 * Thus for this example it would return
-	 *
-	 * {A:2, C:1}
-	 *
-	 * TODO: this should be replaced by a structure considering not
-	 * only equivalence but also implication as well.
-	 */
-	static HandleSeqUCounter group_eq(const HandleSeqSeq& partition,
-	                                  const Handle& var);
-
-	/**
 	 * For each joint variable of pattern (variable that appears in
 	 * more than one partition block) calculate the probability
-	 * estimate of being assigned the same value across all blocks.
+	 * estimate of being assigned the same value across all
+	 * blocks. That implementation takes into account syntactical
+	 * abstraction between blocks in order to better estimate variable
+	 * occurance equality (see the comment above isurp).
 	 */
 	static double eq_prob(const HandleSeqSeq& partition,
 	                      const Handle& pattern,
 	                      const HandleSeq& db);
-
-	/**
-	 * Alternate implementation of eq_prob. Takes into syntactical
-	 * abstraction between blocks in order to better estimate variable
-	 * occurance equality (see the comment above isurp).
-	 */
-	static double eq_prob_alt(const HandleSeqSeq& partition,
-	                          const Handle& pattern,
-	                          const HandleSeq& db);
 
 	/**
 	 * Key of the empirical truth value

--- a/opencog/miner/Surprisingness.h
+++ b/opencog/miner/Surprisingness.h
@@ -23,11 +23,9 @@
 #ifndef OPENCOG_SURPRISINGNESS_H_
 #define OPENCOG_SURPRISINGNESS_H_
 
-#include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/unify/Unify.h>
 #include <opencog/ure/BetaDistribution.h>
 
 namespace opencog
@@ -36,9 +34,6 @@ namespace opencog
 /**
  * Collection of tools to calculate pattern surprisingness.
  */
-
-typedef std::vector<HandleSeqSeq> HandleSeqSeqSeq;
-typedef Counter<HandleSeq, unsigned> HandleSeqUCounter;
 
 class Surprisingness {
 public:
@@ -352,63 +347,6 @@ public:
 	static double dst_from_interval(double l, double u, double v);
 
 	/**
-	 * Given a handle h and a sequence of sequences of handles, insert
-	 * h in front of each subsequence, duplicating each sequence with
-	 * its augmented subsequence. For instance
-	 *
-	 * h = D
-	 * hss = [[A],[B,C]]
-	 *
-	 * returns
-	 *
-	 * [[[D,A],[B,C]],[[A],[D,B,C]],[[A],[B,C],[D]]]
-	 */
-	static HandleSeqSeqSeq combinatorial_insert(const Handle& h,
-	                                            const HandleSeqSeq& hss);
-	static HandleSeqSeqSeq combinatorial_insert(const Handle& h,
-	                                            HandleSeqSeq::const_iterator from,
-	                                            HandleSeqSeq::const_iterator to);
-
-	/**
-	 * Given a HandleSeq hs, produce all partitions of hs. For instance
-	 * if hs is the following
-	 *
-	 * c = [A,B,C]
-	 *
-	 * return
-	 *
-	 * [[[A],[C],[B]],
-	 *  [[C,A],[B]],
-	 *  [[C],[B,A]],
-	 *  [[A],[C,B]],
-	 *  [[C,B,A]]]
-	 */
-	static HandleSeqSeqSeq partitions(const HandleSeq& hs);
-	static HandleSeqSeqSeq partitions(HandleSeq::const_iterator from,
-	                                  HandleSeq::const_iterator to);
-
-	/**
-	 * Like partitions but takes a pattern. Also the partition block
-	 * corresponding to the full set has been removed (since it is
-	 * already the block corresponding to the full pattern). For
-	 * instance
-	 *
-	 * pattern = Lambda
-	 *             And
-	 *               A
-	 *               B
-	 *               C
-	 *
-	 * return
-	 *
-	 * [[[A],[C],[B]],
-	 *  [[C,A],[B]],
-	 *  [[C],[B,A]],
-	 *  [[A],[C,B]]]
-	 */
-	static HandleSeqSeqSeq partitions_without_pattern(const Handle& pattern);
-
-	/**
 	 * Convert a partition block [A,B] into a pattern like
 	 *
 	 * Lambda
@@ -716,89 +654,6 @@ public:
 	                          const Handle& var);
 
 	/**
-	 * Tell whether the left block/subpattern is is syntactically more
-	 * abstract than the right block/subpattern relative to a given
-	 * variable.
-	 *
-	 * For instance
-	 *
-	 * l_blk = { List X Y Z }
-	 * r_blk = { List W A Z }
-	 *
-	 * l_blk is more abstract than r_blk relative to Z because the
-	 * matching values of Z in l_blk is a subset of the matching values
-	 * of Z in l_blk.
-	 */
-	static bool is_syntax_more_abstract(const HandleSeq& l_blk,
-	                                    const HandleSeq& r_blk,
-	                                    const Handle& var);
-
-	/**
-	 * List above but takes scope links instead of blocks (whether each
-	 * scope link has the conjunction of clauses of its block as body).
-	 *
-	 * TODO: for now, this code relies on unification. However it can
-	 * certainly be optimized by not relying on unification and being
-	 * re-implemented instead, and perhaps it could then be merged to
-	 * the unification code.
-	 */
-	static bool is_syntax_more_abstract(const Handle& l_pat,
-	                                    const Handle& r_pat,
-	                                    const Handle& var);
-
-	/**
-	 * Like is_syntax_more_abstract but takes into account a bit of
-	 * semantics as well (though none that requires data), in
-	 * particular it handles conjunctions of clauses such that l_pat is
-	 * more abstract if there exists a partition lp of l_pat (meaning a
-	 * partition of conjunctions of clauses in l_pat) such that there
-	 * exists a subset rs of r_pat (meaning a subset of clauses of
-	 * r_pat) such that rs is a syntactic specialization, relative to
-	 * var, of each block lb of lp.
-	 *
-	 * For instance
-	 *
-	 * l_pat = Lambda
-	 *           X Y Z
-	 *           And
-	 *             Inheritance
-	 *               X
-	 *               Z
-	 *             Inheritance
-	 *               Y
-	 *               Z
-	 *
-	 * r_pat = Lambda
-	 *           Z
-	 *           Inheritance
-	 *             A
-	 *             Z
-	 *
-	 * var = Z
-	 *
-	 * l_pat is indeed an abstraction of r_pat because there exists a
-	 * partition lp = { {Inheritance X Z}, {Inheritance Y Z} } such
-	 * that the subset { Inheritance A Z} is a syntactic specialization
-	 * of each block of lp.
-	 */
-	static bool is_more_abstract(const Handle& l_pat,
-	                             const Handle& r_pat,
-	                             const Handle& var);
-
-	/**
-	 * Like above but consider list of clauses instead of patterns.
-	 */
-	static bool is_more_abstract(const HandleSeq& l_blk,
-	                             const HandleSeq& r_blk,
-	                             const Handle& var);
-
-	/**
-	 * Like powerset but return a sequence of sequences instead of set
-	 * of sets. Discard the empty sequence.
-	 */
-	static HandleSeqSeq powerseq_without_empty(const HandleSeq& blk);
-
-	/**
 	 * Return true iff l_blk is strictly more abstract than r_blk
 	 * relative to var. That is more abstract and not equivalent.
 	 */
@@ -807,52 +662,10 @@ public:
 	                                      const Handle& var);
 
 	/**
-	 * Return true iff var_val is a pair with the first element a
-	 * variable in vars, and the second element a value (non-variable).
-	 */
-	static bool is_value(const Unify::HandleCHandleMap::value_type& var_val,
-	                     const Variables& vars);
-
-	/**
 	 * Sort the partition such that if block A is strictly more
 	 * abstract than block B relative var, then A occurs before B.
 	 */
 	static void rank_by_abstraction(HandleSeqSeq& partition, const Handle& var);
-
-	/**
-	 * Copy all subpatterns/blocks where var appears. Also remove all
-	 * parts of the subpatterns that are not strongly connected with to
-	 * it relative to var.
-	 *
-	 * So for instance
-	 *
-	 * partition = { { Inheritance X Y, Inheritance Z A},
-	 *               { Inheritance X B, Inheritance Z Y} }
-	 *
-	 * var = Y
-	 *
-	 * returns
-	 *
-	 * { {Inheritance Z Y } }
-	 *
-	 * because
-	 *
-	 * 1. Y only appears in the second block
-	 *
-	 * 2. within that block
-	 *
-	 *    Inheritance X B
-	 *
-	 *    is not strongly connected to the component where Y appears.
-	 *
-	 * Ignoring non-strongly connected components allows to speed up
-	 * Surprisingness::value_count as well as covering more cases in
-	 * is_more_abstract.
-	 */
-	static HandleSeqSeq connected_subpatterns_with_var(const HandleSeqSeq& partition,
-	                                                   const Handle& var);
-	static HandleSeq connected_subpattern_with_var(const HandleSeq& blk,
-	                                               const Handle& var);
 
 	/**
 	 * For each joint variable of pattern (variable that appears in
@@ -947,13 +760,6 @@ public:
 	 */
 	static void log_pdf(const BetaDistribution& bd, int bins);
 };
-
-/**
- * Given a partition, that is a sequence of blocks, where each
- * block is a sequence of handles, return
- */
-std::string oc_to_string(const HandleSeqSeqSeq& hsss,
-                         const std::string& indent=empty_string);
 
 } // ~namespace opencog
 

--- a/opencog/miner/Surprisingness.h
+++ b/opencog/miner/Surprisingness.h
@@ -715,15 +715,6 @@ public:
 	                          const Handle& r_pat,
 	                          const Handle& var);
 
-	static HandleSeqUCounter::const_iterator find_equivalent(
-		const HandleSeqUCounter& partition_c,
-		const HandleSeq& block,
-		const Handle& var);
-	static HandleSeqUCounter::iterator find_equivalent(
-		HandleSeqUCounter& partition_c,
-		const HandleSeq& block,
-		const Handle& var);
-
 	/**
 	 * Tell whether the left block/subpattern is is syntactically more
 	 * abstract than the right block/subpattern relative to a given

--- a/opencog/miner/Surprisingness.h
+++ b/opencog/miner/Surprisingness.h
@@ -690,7 +690,7 @@ public:
 	                           const Handle& var);
 
 	/**
-	 * Tell whether 2 blocks/subpatterns are equivalent relatie to a
+	 * Tell whether 2 blocks/subpatterns are equivalent relative to a
 	 * given variable. Basically, whether both block are semantically
 	 * equivalent and var is in the same position in both of them.
 	 *

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -31,6 +31,7 @@
 #include <opencog/util/random.h>
 #include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/atoms/truthvalue/SimpleTruthValue.h>
+#include <opencog/atoms/pattern/GetLink.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/miner/HandleTree.h>
 #include <opencog/miner/Miner.h>
@@ -141,7 +142,8 @@ public:
 	void tearDown();
 
 	// Auxiliary methods
-	void test_remove_useless_clauses();
+	void test_remove_useless_clauses_1();
+	void test_remove_useless_clauses_2();
 	void test_compose_1();
 	void test_compose_2();
 	void test_compose_3();
@@ -165,6 +167,7 @@ public:
 	void test_ABAB();
 	void test_AAAA();
 	void test_transitivity();
+	void test_long_transitivity();
 	void test_no_transitivity();
 	void test_evaluation();
 	void test_2conjuncts_1();
@@ -314,7 +317,7 @@ void MinerUTest::tearDown()
 	_tmp_as.clear();
 }
 
-void MinerUTest::test_remove_useless_clauses()
+void MinerUTest::test_remove_useless_clauses_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -326,6 +329,46 @@ void MinerUTest::test_remove_useless_clauses()
 	logger().debug() << "expected = " << oc_to_string(expected);
 
 	TS_ASSERT(content_eq(result, expected));
+}
+
+void MinerUTest:: test_remove_useless_clauses_2()
+{
+	// Clause 3 is more abstract than all clauses of the pattern and
+	// does not introduce new variables, therefore it is redundant and
+	// can be removed.
+	Handle
+		vardecl = al(VARIABLE_LIST, X, Y),
+		clause1 = al(INHERITANCE_LINK, X, C1),
+		clause2 = al(INHERITANCE_LINK, C2, Y),
+		clause3 = al(INHERITANCE_LINK, X, Y),
+		pattern = MinerUtils::mk_pattern(vardecl, {clause1, clause2, clause3});
+
+	Handle
+		reduced = MinerUtils::remove_useless_clauses(pattern),
+		expect = MinerUtils::mk_pattern(vardecl, {clause1, clause2});
+
+	logger().debug() << "pattern = " << oc_to_string(pattern);
+	logger().debug() << "reduced = " << oc_to_string(reduced);
+
+	// First check the result is as expected
+	TS_ASSERT(content_eq(reduced, expect));
+
+	// Second check that both pattern and result have the same matches
+	unsigned n_cpts = 1000;
+	Type node_t = CONCEPT_NODE;
+	HandleSeq cpts = MinerUTestUtils::populate_nodes(_as, n_cpts, node_t, "C");
+	Type link_t = INHERITANCE_LINK;
+	MinerUTestUtils::populate_links(_as, cpts, link_t, 2, 0.1);
+	// logger().debug() << "_as = " << _as;
+	GetLinkPtr pattern_gl = createGetLink(HandleSeq{pattern});
+	Handle pattern_results = HandleCast(pattern_gl->execute(&_as));
+	GetLinkPtr reduced_gl = createGetLink(HandleSeq{reduced});
+	Handle reduced_results = HandleCast(pattern_gl->execute(&_as));
+
+	logger().debug() << "pattern_results = " << oc_to_string(pattern_results);
+	logger().debug() << "reduced_results = " << oc_to_string(reduced_results);
+
+	TS_ASSERT_EQUALS(pattern_results, reduced_results);
 }
 
 void MinerUTest::test_compose_1()
@@ -945,6 +988,37 @@ void MinerUTest::test_transitivity()
 	Handle results = ure_pm(db, ms, 50, top, true, 2, 3, 3, false);
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Y, Z)};
+	Handle expected = mk_minsup_eval(ms,
+	                                 MinerUtils::mk_pattern_no_vardecl(clauses));
+
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
+}
+
+void MinerUTest::test_long_transitivity()
+{
+	// Mine transitivity pattern using incremental conjunction
+	// expansion. Check with and without enforce specialization.
+
+	// Define db
+	Handle
+		InhAB = al(INHERITANCE_LINK, A, B),
+		InhBC = al(INHERITANCE_LINK, B, C),
+		InhCD = al(INHERITANCE_LINK, C, D);
+	HandleSeq db{InhAB, InhBC};
+
+	// Run URE pattern miner without enforcing specialization (which is
+	// necessary to mine transitivity).
+	int ms = 1;
+	// TMP: Iteration 6, last result contains redundant
+	// abstraction. Actually doesn't work because it introduces a new
+	// variable. See the 17 total results to find one.
+	Handle results = ure_pm(db, ms, 500, top, true, 3, 4, false);
+	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
+	                     al(INHERITANCE_LINK, Y, Z),
+	                     al(INHERITANCE_LINK, Z, W)};
 	Handle expected = mk_minsup_eval(ms,
 	                                 MinerUtils::mk_pattern_no_vardecl(clauses));
 

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -349,6 +349,7 @@ void MinerUTest:: test_remove_useless_clauses_2()
 
 	logger().debug() << "pattern = " << oc_to_string(pattern);
 	logger().debug() << "reduced = " << oc_to_string(reduced);
+	logger().debug() << "expect = " << oc_to_string(expect);
 
 	// First check the result is as expected
 	TS_ASSERT(content_eq(reduced, expect));

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -973,6 +973,8 @@ void MinerUTest::test_AAAA()
 
 void MinerUTest::test_transitivity()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Mine transitivity pattern using incremental conjunction
 	// expansion. Check with and without enforce specialization.
 
@@ -999,6 +1001,8 @@ void MinerUTest::test_transitivity()
 
 void MinerUTest::test_long_transitivity()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Mine transitivity pattern using incremental conjunction
 	// expansion. Check with and without enforce specialization.
 
@@ -1007,15 +1011,20 @@ void MinerUTest::test_long_transitivity()
 		InhAB = al(INHERITANCE_LINK, A, B),
 		InhBC = al(INHERITANCE_LINK, B, C),
 		InhCD = al(INHERITANCE_LINK, C, D);
-	HandleSeq db{InhAB, InhBC};
+	HandleSeq db{InhAB, InhBC, InhCD};
 
 	// Run URE pattern miner without enforcing specialization (which is
 	// necessary to mine transitivity).
 	int ms = 1;
-	// TMP: Iteration 6, last result contains redundant
-	// abstraction. Actually doesn't work because it introduces a new
-	// variable. See the 17 total results to find one.
-	Handle results = ure_pm(db, ms, 500, top, true, 3, 4, false);
+	int max_iteration = 50;
+	bool conjunction_expansion = true;
+	unsigned max_conjuncts = 3;
+	unsigned max_variables = 4;
+	unsigned max_cnjexp_variables = 4;
+	bool enforce_specialization = false;
+	Handle results = ure_pm(db, ms, max_iteration, top, conjunction_expansion,
+	                        max_conjuncts, max_variables, max_cnjexp_variables,
+	                        enforce_specialization);
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Y, Z),
 	                     al(INHERITANCE_LINK, Z, W)};
@@ -1030,6 +1039,8 @@ void MinerUTest::test_long_transitivity()
 
 void MinerUTest::test_no_transitivity()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Like test_transitivity but enforce specialization, thus should
 	// miss the transitivity pattern.
 

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -61,7 +61,7 @@ private:
 	Handle X, Y, Z, W;
 
 	// Constants
-	Handle A, A1, A2, A3, B, C, C1, C2, C3, D, E, F, G, H;
+	Handle A, A1, A2, A3, B, C, C0, C1, C2, C3, D, E, F, G, H;
 
 	// Pattern miner rule base
 	Handle pm_rb;
@@ -142,6 +142,13 @@ public:
 	void tearDown();
 
 	// Auxiliary methods
+	void test_partitions();
+	void test_is_syntax_more_abstract();
+	void test_is_more_abstract_1();
+	void test_is_more_abstract_2();
+	void test_is_more_abstract_3();
+	// TODO: fix is_more_abstract to support that case
+	void xtest_is_more_abstract_4();
 	void test_remove_useless_clauses_1();
 	void test_remove_useless_clauses_2();
 	void test_compose_1();
@@ -293,6 +300,7 @@ void MinerUTest::setUp()
 	A3 = an(CONCEPT_NODE, "A3");
 	B = an(CONCEPT_NODE, "B");
 	C = an(CONCEPT_NODE, "C");
+	C0 = an(CONCEPT_NODE, "C0");
 	C1 = an(CONCEPT_NODE, "C1");
 	C2 = an(CONCEPT_NODE, "C2");
 	C3 = an(CONCEPT_NODE, "C3");
@@ -315,6 +323,114 @@ void MinerUTest::tearDown()
 {
 	_as.clear();
 	_tmp_as.clear();
+}
+
+// Test partition({A,B,C})
+void MinerUTest::test_partitions()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle A = an(CONCEPT_NODE, "A"),
+		B = an(CONCEPT_NODE, "B"),
+		C = an(CONCEPT_NODE, "C");
+	HandleSeqSeqSeq result = MinerUtils::partitions({A, B, C}),
+		expect = { { {A}, {C}, {B} },
+		           { {C,A}, {B} },
+		           { {C}, {B,A} },
+		           { {A}, {C,B} },
+		           { {C,B,A} } };
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(result, expect);
+}
+
+void MinerUTest::test_is_syntax_more_abstract()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	HandleSeq l_blk{al(LIST_LINK, Z, W, X)};
+	HandleSeq r_blk{al(LIST_LINK, X, Y, X)};
+
+	// Left block/subpattern is syntactically more abstract than
+	// right block/subpattern, relative to X.
+	TS_ASSERT(MinerUtils::is_more_abstract(l_blk, r_blk, X));
+}
+
+void MinerUTest::test_is_more_abstract_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle l_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(PRESENT_LINK,
+	                     al(INHERITANCE_LINK, X, Z),
+	                     al(INHERITANCE_LINK, Y, Z)));
+	Handle r_pat = al(LAMBDA_LINK,
+	                  Z,
+	                  al(INHERITANCE_LINK, C0, Z));
+
+	// Left pattern is more abstract than right pattern, relative to Z.
+	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, Z));
+}
+
+void MinerUTest::test_is_more_abstract_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle l_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y),
+	                  al(INHERITANCE_LINK, X, Z));
+	Handle r_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(PRESENT_LINK,
+	                     al(INHERITANCE_LINK, X, C0),
+	                     al(INHERITANCE_LINK, Z, Y),
+	                     al(INHERITANCE_LINK, Z, C1)));
+
+	// Left pattern is more abstract than right pattern, relative to X.
+	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, X));
+}
+
+void MinerUTest::test_is_more_abstract_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle l_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(PRESENT_LINK,
+	                     al(INHERITANCE_LINK, X, Y),
+	                     al(INHERITANCE_LINK, Z, C1)));
+	Handle r_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Z),
+	                  al(PRESENT_LINK,
+	                     al(INHERITANCE_LINK, X, C0),
+	                     al(INHERITANCE_LINK, Z, Y)));
+
+	// Left pattern is more abstract than right pattern, relative to X.
+	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, X));
+
+	// Left pattern is more abstract than right pattern, relative to Y.
+	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, Y));
+}
+
+void MinerUTest::xtest_is_more_abstract_4()
+{
+	Handle l_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(PRESENT_LINK,
+	                     al(INHERITANCE_LINK, X, Y),
+	                     al(INHERITANCE_LINK, Z, Y)));
+	Handle r_pat = al(LAMBDA_LINK,
+	                  al(VARIABLE_LIST, X, Z),
+	                  al(INHERITANCE_LINK, Z, C0));
+
+	// Left pattern is more abstract than right pattern, relative to X.
+	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, X));
+
+	// Left pattern is more abstract than right pattern, relative to Y.
+	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, Y));
 }
 
 void MinerUTest::test_remove_useless_clauses_1()

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -143,14 +143,18 @@ public:
 
 	// Auxiliary methods
 	void test_partitions();
-	void test_is_syntax_more_abstract();
+	void test_is_syntax_more_abstract_1();
+	void test_is_syntax_more_abstract_2();
+	void test_is_syntax_more_abstract_3();
 	void test_is_more_abstract_1();
 	void test_is_more_abstract_2();
 	void test_is_more_abstract_3();
 	// TODO: fix is_more_abstract to support that case
 	void xtest_is_more_abstract_4();
+	void test_is_more_abstract_foreach_var();
 	void test_remove_useless_clauses_1();
 	void test_remove_useless_clauses_2();
+	void test_remove_useless_clauses_3();
 	void test_compose_1();
 	void test_compose_2();
 	void test_compose_3();
@@ -167,6 +171,7 @@ public:
 	// Pattern miner
 	void test_A();
 	void test_AB();
+	void test_AB_redundant_cnj();
 	void test_AB_AC();
 	void test_AB_AC_BC();
 	void test_AB_ABC();
@@ -279,7 +284,7 @@ MinerUTest::MinerUTest() : _scm(&_as), _tmp_scm(&_tmp_as)
 	// Configure scheme load-paths that are common for all tests.
 	_scm.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR
 	          "/tests/miner/scm\")");
-	
+
 	// Load modules
 	_scm.eval("(use-modules (opencog))");
 	std::string rs = _scm.eval("(use-modules (opencog miner))");
@@ -346,7 +351,31 @@ void MinerUTest::test_partitions()
 	TS_ASSERT_EQUALS(result, expect);
 }
 
-void MinerUTest::test_is_syntax_more_abstract()
+void MinerUTest::test_is_syntax_more_abstract_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	HandleSeq l_blk{al(INHERITANCE_LINK, X, Y)};
+	HandleSeq r_blk{al(INHERITANCE_LINK, Y, Z)};
+
+	// Left block/subpattern is not syntactically more abstract than
+	// right block/subpattern, relative to Y.
+	TS_ASSERT(not MinerUtils::is_blk_syntax_more_abstract(l_blk, r_blk, Y));
+}
+
+void MinerUTest::test_is_syntax_more_abstract_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	HandleSeq l_blk{al(INHERITANCE_LINK, X, Y)};
+	HandleSeq r_blk{al(INHERITANCE_LINK, A, Y)};
+
+	// Left block/subpattern is syntactically more abstract than right
+	// block/subpattern, relative to Y.
+	TS_ASSERT(MinerUtils::is_blk_syntax_more_abstract(l_blk, r_blk, Y));
+}
+
+void MinerUTest::test_is_syntax_more_abstract_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -355,8 +384,11 @@ void MinerUTest::test_is_syntax_more_abstract()
 
 	// Left block/subpattern is syntactically more abstract than
 	// right block/subpattern, relative to X.
-	TS_ASSERT(MinerUtils::is_more_abstract(l_blk, r_blk, X));
+	TS_ASSERT(MinerUtils::is_blk_syntax_more_abstract(l_blk, r_blk, X));
+	// However the converse is not true.
+	TS_ASSERT(not MinerUtils::is_blk_syntax_more_abstract(r_blk, l_blk, X));
 }
+
 
 void MinerUTest::test_is_more_abstract_1()
 {
@@ -372,7 +404,7 @@ void MinerUTest::test_is_more_abstract_1()
 	                  al(INHERITANCE_LINK, C0, Z));
 
 	// Left pattern is more abstract than right pattern, relative to Z.
-	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, Z));
+	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, Z));
 }
 
 void MinerUTest::test_is_more_abstract_2()
@@ -390,7 +422,7 @@ void MinerUTest::test_is_more_abstract_2()
 	                     al(INHERITANCE_LINK, Z, C1)));
 
 	// Left pattern is more abstract than right pattern, relative to X.
-	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, X));
+	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, X));
 }
 
 void MinerUTest::test_is_more_abstract_3()
@@ -409,10 +441,10 @@ void MinerUTest::test_is_more_abstract_3()
 	                     al(INHERITANCE_LINK, Z, Y)));
 
 	// Left pattern is more abstract than right pattern, relative to X.
-	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, X));
+	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, X));
 
 	// Left pattern is more abstract than right pattern, relative to Y.
-	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, Y));
+	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, Y));
 }
 
 void MinerUTest::xtest_is_more_abstract_4()
@@ -422,15 +454,39 @@ void MinerUTest::xtest_is_more_abstract_4()
 	                  al(PRESENT_LINK,
 	                     al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Z, Y)));
+	// TODO: this seems bogus, X is not even in the body
 	Handle r_pat = al(LAMBDA_LINK,
 	                  al(VARIABLE_LIST, X, Z),
 	                  al(INHERITANCE_LINK, Z, C0));
 
 	// Left pattern is more abstract than right pattern, relative to X.
-	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, X));
+	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, X));
 
 	// Left pattern is more abstract than right pattern, relative to Y.
-	TS_ASSERT(MinerUtils::is_more_abstract(l_pat, r_pat, Y));
+	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, Y));
+}
+
+void MinerUTest:: test_is_more_abstract_foreach_var()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// No clause is more abstract than the others, thus nothing should
+	// be removed.
+	Handle
+		clause1 = al(INHERITANCE_LINK, X, Y),
+		clause2 = al(INHERITANCE_LINK, Y, Z),
+		clause3 = al(INHERITANCE_LINK, Z, W);
+
+	bool
+		result = MinerUtils::is_more_abstract_foreach_var(clause2,
+		                                                  { clause1, clause3 }),
+		expect = false;
+
+	logger().debug() << "result = " << result;
+	logger().debug() << "expect = " << expect;
+
+	// Check the result is as expected
+	TS_ASSERT_EQUALS(result, expect);
 }
 
 void MinerUTest::test_remove_useless_clauses_1()
@@ -449,6 +505,8 @@ void MinerUTest::test_remove_useless_clauses_1()
 
 void MinerUTest:: test_remove_useless_clauses_2()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Clause 3 is more abstract than all clauses of the pattern and
 	// does not introduce new variables, therefore it is redundant and
 	// can be removed.
@@ -471,7 +529,7 @@ void MinerUTest:: test_remove_useless_clauses_2()
 	TS_ASSERT(content_eq(reduced, expect));
 
 	// Second check that both pattern and result have the same matches
-	unsigned n_cpts = 1000;
+	unsigned n_cpts = 100;
 	Type node_t = CONCEPT_NODE;
 	HandleSeq cpts = MinerUTestUtils::populate_nodes(_as, n_cpts, node_t, "C");
 	Type link_t = INHERITANCE_LINK;
@@ -486,6 +544,31 @@ void MinerUTest:: test_remove_useless_clauses_2()
 	logger().debug() << "reduced_results = " << oc_to_string(reduced_results);
 
 	TS_ASSERT_EQUALS(pattern_results, reduced_results);
+}
+
+void MinerUTest:: test_remove_useless_clauses_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// No clause is more abstract than the others, thus nothing should
+	// be removed.
+	Handle
+		vardecl = al(VARIABLE_LIST, X, Y, Z, W),
+		clause1 = al(INHERITANCE_LINK, X, Y),
+		clause2 = al(INHERITANCE_LINK, Y, Z),
+		clause3 = al(INHERITANCE_LINK, Z, W),
+		pattern = MinerUtils::mk_pattern(vardecl, {clause1, clause2, clause3});
+
+	Handle
+		reduced = MinerUtils::remove_useless_clauses(pattern),
+		expect = pattern;
+
+	logger().debug() << "pattern = " << oc_to_string(pattern);
+	logger().debug() << "reduced = " << oc_to_string(reduced);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	// Check the result is as expected
+	TS_ASSERT(content_eq(reduced, expect));
 }
 
 void MinerUTest::test_compose_1()
@@ -836,6 +919,57 @@ void MinerUTest::test_AB()
 	TS_ASSERT(content_eq(ure_results, ure_expected));
 }
 
+void MinerUTest::test_AB_redundant_cnj()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Like test_AB but look for 3-conjuncts patterns. Test that the
+	// solution set does not contain
+	//
+	// (LambdaLink
+	//   (VariableList
+	//     (VariableNode "$X")
+	//     (VariableNode "$Y")
+	//   )
+	//   (PresentLink
+	//     (InheritanceLink
+	//       (ConceptNode "A")
+	//       (VariableNode "$Y")
+	//     )
+	//     (InheritanceLink
+	//       (VariableNode "$X")
+	//       (VariableNode "$Y")
+	//     )
+	//     (InheritanceLink
+	//       (VariableNode "$X")
+	//       (ConceptNode "B")
+	//     )
+	//   )
+	// )
+	//
+	// as such pattern should be removed by the conjunction expansion
+	// rule (via MinerUTest::remove_useless_clauses).
+
+	// Define db
+	Handle InhAB = al(INHERITANCE_LINK, A, B);
+	HandleSeq db{InhAB};
+
+	// Run URE pattern miner without enforcing specialization (which is
+	// necessary to mine transitivity).
+	int ms = 1;
+	Handle results = ure_pm(db, ms, 50, top, true, 3, 2, 2, false);
+	HandleSeq clauses = {al(INHERITANCE_LINK, A, Y),
+	                     al(INHERITANCE_LINK, Y, B),
+	                     al(INHERITANCE_LINK, X, Y)};
+	Handle no_expect = mk_minsup_eval(ms,
+	                                  MinerUtils::mk_pattern_no_vardecl(clauses));
+
+	logger().debug() << "results = " << oc_to_string(results->getOutgoingSet());
+	logger().debug() << "no_expect = " << oc_to_string(no_expect);
+
+	TS_ASSERT(not is_in(no_expect, results->getOutgoingSet()));
+}
+
 void MinerUTest::test_AB_AC()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
@@ -849,18 +983,6 @@ void MinerUTest::test_AB_AC()
 	Handle VarXY = al(VARIABLE_LIST, X, Y),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhAY = al(INHERITANCE_LINK, A, Y);
-
-	// NEXT TODO: get rid of the C++ pattern miner, as it is not used at all
-
-	// // Run C++ pattern miner (using _as for testing more diverse
-	// // content)
-	// HandleTree cpp_results = cpp_pm(_as, 2);
-	// Handle cpp_expected = MinerUtils::mk_pattern(Y, {InhAY});
-
-	// logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
-	// logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
-
-	// TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner (using _as for testing more diverse
 	// content)
@@ -1139,9 +1261,10 @@ void MinerUTest::test_long_transitivity()
 	unsigned max_variables = 4;
 	unsigned max_cnjexp_variables = 4;
 	bool enforce_specialization = false;
+	double complexity_penalty = 1.0;
 	Handle results = ure_pm(db, ms, max_iteration, top, conjunction_expansion,
 	                        max_conjuncts, max_variables, max_cnjexp_variables,
-	                        enforce_specialization);
+	                        enforce_specialization, complexity_penalty);
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Y, Z),
 	                     al(INHERITANCE_LINK, Z, W)};
@@ -1722,8 +1845,12 @@ void MinerUTest::test_vqa()
 		_tmp_scm.eval("(load-from-path \"QA_knowledge_base_v2_no_duplicates.scm\")");
 	logger().debug() << "rs = " << rs;
 
-	// Start from top, conjunctions will be grown incrementally
-	Handle initpat = top;
+	// Start from (Member X Y), conjunctions will be grown
+	// incrementally.
+	Handle
+		VarXY = al(VARIABLE_LIST, X, Y),
+		MemXY = al(MEMBER_LINK, X, Y),
+		initpat = MinerUtils::mk_pattern(VarXY, {MemXY});
 
 	// The pattern of interest looks like
 	//
@@ -1748,7 +1875,6 @@ void MinerUTest::test_vqa()
 	// TODO: find a better pattern of interest
 	Handle
 		VarXYZ = al(VARIABLE_LIST, X, Y, Z),
-		MemXY = al(MEMBER_LINK, X, Y),
 		MemZY = al(MEMBER_LINK, Z, Y),
 		expected = MinerUtils::mk_pattern(VarXYZ, {MemXY, MemZY});
 
@@ -1757,26 +1883,26 @@ void MinerUTest::test_vqa()
 	// Run URE pattern miner
 	bool conjunction_expansion = true;
 	int minsup = 500;
-	int max_iteration = 20;
+	int max_iteration = 5;
 	unsigned max_conjuncts = 2;
-	unsigned max_variables = UINT_MAX;
-	unsigned max_cnjexp_variables = UINT_MAX;
+	unsigned max_variables = 3;
+	unsigned max_cnjexp_variables = 3;
 	bool enforce_specialization = false;
 	double complexity_penalty = 1;
-	Handle ure_results = ure_pm(_tmp_as, minsup, max_iteration,
-	                            initpat,
-	                            conjunction_expansion,
-	                            max_conjuncts,
-	                            max_variables,
-	                            max_cnjexp_variables,
-	                            enforce_specialization,
-	                            complexity_penalty),
-		ure_expected = mk_minsup_eval(minsup, expected);
+	Handle results = ure_pm(_tmp_as, minsup, max_iteration,
+	                        initpat,
+	                        conjunction_expansion,
+	                        max_conjuncts,
+	                        max_variables,
+	                        max_cnjexp_variables,
+	                        enforce_specialization,
+	                        complexity_penalty),
+		expect = mk_minsup_eval(minsup, expected);
 
-	logger().debug() << "ure_results = " << oc_to_string(ure_results);
-	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
+	logger().debug() << "results = " << oc_to_string(results->getOutgoingSet());
+	logger().debug() << "expect = " << oc_to_string(expect);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(is_in(expect, results->getOutgoingSet()));
 }
 
 #undef al

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -26,6 +26,8 @@
 
 #include <boost/range/algorithm/sort.hpp>
 
+#include <opencog/util/random.h>
+#include <opencog/util/algorithm.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/ure/forwardchainer/ForwardChainer.h>
 #include <opencog/ure/backwardchainer/BackwardChainer.h>
@@ -350,4 +352,30 @@ HandleSeq MinerUTestUtils::ure_surp(AtomSpace& as,
 			return lh->getTruthValue()->get_mean() > rh->getTruthValue()->get_mean();
 		});
 	return surp_results_seq;
+}
+
+HandleSeq MinerUTestUtils::populate_nodes(AtomSpace& as,
+                                          unsigned n,
+                                          Type type,
+                                          const std::string& prefix)
+{
+	// Create nodes i for i in [0, n)
+	HandleSeq nodes(n);
+	for (unsigned i = 0; i < n; i++)
+		nodes[i] = as.add_node(type, prefix + std::to_string(i));
+	return nodes;
+}
+
+HandleSeq MinerUTestUtils::populate_links(AtomSpace& as,
+                                          const HandleSeq& hs,
+                                          Type type,
+                                          unsigned arity,
+                                          double p)
+{
+	// Use set to ignore duplicate in case type is unordered
+	HandleSet links;
+	for (const HandleSeq& outgoing : cartesian_product(hs, arity))
+		if (biased_randbool(p))
+			links.insert(as.add_link(type, outgoing));
+	return HandleSeq(links.begin(), links.end());
 }

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -297,6 +297,28 @@ public:
 	                          const Handle& surp_rb,
 	                          const std::string& mode,
 	                          unsigned max_conjuncts);
+
+	/**
+	 * Populate the given atomspace with n nodes of a given type, named
+	 * prefix + std::to_string(i) with i in [0, n).
+	 *
+	 * The handles of the populated atoms.
+	 */
+	static HandleSeq populate_nodes(AtomSpace& as,
+	                                unsigned n,
+	                                Type type,
+	                                const std::string& prefix);
+
+	/**
+	 * Populate the given atomspace by creating links of a given type
+	 * and arity with probability p between any arity handles from
+	 * hs. Return the handles of the populated atoms.
+	 */
+	static HandleSeq populate_links(AtomSpace& as,
+	                                const HandleSeq& hs,
+	                                Type type,
+	                                unsigned arity,
+	                                double p);
 };
 
 } // ~namespace opencog

--- a/tests/miner/SurprisingnessUTest.cxxtest
+++ b/tests/miner/SurprisingnessUTest.cxxtest
@@ -77,8 +77,8 @@ private:
 	// Inheritance is not taken into account.
 	void populate_uniform_inheritance_links(unsigned n_cpts, double ip);
 
-	// Generate Lists of ari concepts among n_cpts
-	void populate_uniform_list_links(unsigned n_cpts, unsigned ari, double ip);
+	// Generate ternary Lists of concepts among n_cpts
+	void populate_uniform_ternary_list_links(unsigned n_cpts, double ip);
 
 public:
 	SurprisingnessUTest();
@@ -189,9 +189,8 @@ void SurprisingnessUTest::populate_uniform_inheritance_links(unsigned n_cpts,
 	// logger().debug() << "AtomSpace:" << std::endl << _as;
 }
 
-void SurprisingnessUTest::populate_uniform_list_links(unsigned n_cpts,
-                                                      unsigned ari,
-                                                      double ip)
+void SurprisingnessUTest::populate_uniform_ternary_list_links(unsigned n_cpts,
+                                                              double ip)
 {
 	// Create concepts Ci for i in [0, n_cpts)
 	HandleSeq cpts = populate_concepts(n_cpts);
@@ -1224,7 +1223,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_7()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Create data base
-	populate_uniform_list_links(50, 3, 0.1);
+	populate_uniform_ternary_list_links(50, 0.1);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -1287,7 +1286,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_8()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Create data base
-	populate_uniform_list_links(50, 3, 0.1);
+	populate_uniform_ternary_list_links(50, 0.1);
 
 	// Create pattern to measure surprisingness of
 	//

--- a/tests/miner/SurprisingnessUTest.cxxtest
+++ b/tests/miner/SurprisingnessUTest.cxxtest
@@ -108,10 +108,7 @@ public:
 	void test_nisurp_no_linkage_synthetic_2();
 
 	// Test surprisingness with joint variables on synthetic data
-	// TODO: that one is really difficult to get because it ultimately
-	// depends on data generator to determine the universe of possible
-	// values of each variable, which is hard to guess.
-	void xtest_nisurp_linkage_synthetic_1();
+	void test_nisurp_linkage_synthetic_1();
 	void test_nisurp_linkage_synthetic_2();
 	void test_nisurp_linkage_synthetic_3();
 	void test_nisurp_linkage_synthetic_4();
@@ -209,7 +206,7 @@ SurprisingnessUTest::SurprisingnessUTest() : _scm(&_as)
 	randGen().seed(0);
 
 	// Main logger
-	logger().set_level(Logger::INFO);
+	logger().set_level(Logger::DEBUG);
 	logger().set_timestamp_flag(false);
 	logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);
@@ -731,10 +728,14 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_2()
 // Since the data set is generated with independent assumptions, it
 // should not be surprising either (if linkage is properly taken into
 // account).
-void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_1()
+//
+	// TODO: that one is really difficult to get because it ultimately
+	// depends on data generator to determine the universe of possible
+	// values of each variable, which is hard to guess.
+void SurprisingnessUTest::test_nisurp_linkage_synthetic_1()
 {
 	// Create data base
-	populate_uniform_inheritance_links(1000, 0.1);
+	populate_uniform_inheritance_links(3, 0.8);
 
 	// Create pattern to measure surprisingness of
 	//
@@ -766,7 +767,7 @@ void SurprisingnessUTest::xtest_nisurp_linkage_synthetic_1()
 
 	TS_ASSERT(content_eq(expected, surp_front));
 
-	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.6);
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.8);
 }
 
 // Similar to above for pattern
@@ -785,7 +786,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_2()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Create data base
-	populate_uniform_inheritance_links(10000, 0.001);
+	populate_uniform_inheritance_links(10000, 0.00001);
 
 	// Create pattern to measure surprisingness of
 	//

--- a/tests/miner/SurprisingnessUTest.cxxtest
+++ b/tests/miner/SurprisingnessUTest.cxxtest
@@ -88,13 +88,6 @@ public:
 	void tearDown();
 
 	// Test auxilary methods
-	void test_partitions();
-	void test_is_syntax_more_abstract();
-	void test_is_more_abstract_1();
-	void test_is_more_abstract_2();
-	void test_is_more_abstract_3();
-	// TODO: fix is_more_abstract to support that case
-	void xtest_is_more_abstract_4();
 	void test_is_strictly_more_abstract();
 	void test_subsmp();
 	void test_emp_prob_bs_1();
@@ -254,114 +247,6 @@ void SurprisingnessUTest::setUp()
 void SurprisingnessUTest::tearDown()
 {
 	_as.clear();
-}
-
-// Test partition({A,B,C})
-void SurprisingnessUTest::test_partitions()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-	Handle A = an(CONCEPT_NODE, "A"),
-		B = an(CONCEPT_NODE, "B"),
-		C = an(CONCEPT_NODE, "C");
-	HandleSeqSeqSeq result = Surprisingness::partitions({A, B, C}),
-		expect = { { {A}, {C}, {B} },
-		           { {C,A}, {B} },
-		           { {C}, {B,A} },
-		           { {A}, {C,B} },
-		           { {C,B,A} } };
-
-	logger().debug() << "result = " << oc_to_string(result);
-	logger().debug() << "expect = " << oc_to_string(expect);
-
-	TS_ASSERT_EQUALS(result, expect);
-}
-
-void SurprisingnessUTest::test_is_syntax_more_abstract()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-	HandleSeq l_blk{al(LIST_LINK, Z, W, X)};
-	HandleSeq r_blk{al(LIST_LINK, X, Y, X)};
-
-	// Left block/subpattern is syntactically more abstract than
-	// right block/subpattern, relative to X.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_blk, r_blk, X));
-}
-
-void SurprisingnessUTest::test_is_more_abstract_1()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-	Handle l_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y, Z),
-	                  al(PRESENT_LINK,
-	                     al(INHERITANCE_LINK, X, Z),
-	                     al(INHERITANCE_LINK, Y, Z)));
-	Handle r_pat = al(LAMBDA_LINK,
-	                  Z,
-	                  al(INHERITANCE_LINK, C0, Z));
-
-	// Left pattern is more abstract than right pattern, relative to Z.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, Z));
-}
-
-void SurprisingnessUTest::test_is_more_abstract_2()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-	Handle l_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y),
-	                  al(INHERITANCE_LINK, X, Z));
-	Handle r_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y, Z),
-	                  al(PRESENT_LINK,
-	                     al(INHERITANCE_LINK, X, C0),
-	                     al(INHERITANCE_LINK, Z, Y),
-	                     al(INHERITANCE_LINK, Z, C1)));
-
-	// Left pattern is more abstract than right pattern, relative to X.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, X));
-}
-
-void SurprisingnessUTest::test_is_more_abstract_3()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-	Handle l_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y, Z),
-	                  al(PRESENT_LINK,
-	                     al(INHERITANCE_LINK, X, Y),
-	                     al(INHERITANCE_LINK, Z, C1)));
-	Handle r_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Z),
-	                  al(PRESENT_LINK,
-	                     al(INHERITANCE_LINK, X, C0),
-	                     al(INHERITANCE_LINK, Z, Y)));
-
-	// Left pattern is more abstract than right pattern, relative to X.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, X));
-
-	// Left pattern is more abstract than right pattern, relative to Y.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, Y));
-}
-
-void SurprisingnessUTest::xtest_is_more_abstract_4()
-{
-	Handle l_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y, Z),
-	                  al(PRESENT_LINK,
-	                     al(INHERITANCE_LINK, X, Y),
-	                     al(INHERITANCE_LINK, Z, Y)));
-	Handle r_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Z),
-	                  al(INHERITANCE_LINK, Z, C0));
-
-	// Left pattern is more abstract than right pattern, relative to X.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, X));
-
-	// Left pattern is more abstract than right pattern, relative to Y.
-	TS_ASSERT(Surprisingness::is_more_abstract(l_pat, r_pat, Y));
 }
 
 void SurprisingnessUTest::test_is_strictly_more_abstract()


### PR DESCRIPTION
This PR contains two main features

1. Improve the custom reduction engine for the miner. Remove clauses that are more abstract over each of their variables, thus does not impact the semantics of the pattern. On my test data sets (which are mostly synthetic except the visual QA one) this rules removes from 0% to 50% of patterns, depending on the dataset and settings.

2. Fix surprisingness measure. There was an insane C++ bug in the abstraction detection function, due to gcc not properly disambiguating function calls involving `initializer_list`. So for instance a call of `foo({h})` where `foo` if overloaded both for `Handle` and `HandleSeq` could call the overloaded version of `Handle` instead of `HandleSeq`!!!!!! The moral is that be extremely careful when overloading functions. Make sure that the semantics is the same regardless of whether the function is called with an object or a sequence. If the semantics differ (other than seq vs non seq) then don't overload! Give your functions different names.