### PR TITLE
Support VariableSet

### DIFF
--- a/opencog/miner/HandleTree.cc
+++ b/opencog/miner/HandleTree.cc
@@ -116,7 +116,7 @@ bool all_nodes_in(const HandleSet& cash, HandleTree::iterator it)
 std::string oc_to_string(const HandleTree& ht, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << indent << "size = " << ht.size() << std::endl;
+	ss << indent << "size = " << ht.size();
 	unsigned i = 0;
 	for (HandleTree::iterator it = ht.begin(); it != ht.end(); ++it)
 	{
@@ -124,7 +124,8 @@ std::string oc_to_string(const HandleTree& ht, const std::string& indent)
 		std::string node_indent = indent;
 		dorepeat(depth)
 			node_indent += OC_TO_STRING_INDENT;
-		ss << node_indent << "atom[" << i << ",depth=" << ht.depth(it) << "]:"
+		ss << std::endl << node_indent
+		   << "atom[" << i << ",depth=" << ht.depth(it) << "]:"
 		   << std::endl << oc_to_string(*it, node_indent + OC_TO_STRING_INDENT);
 		++i;
 	}
@@ -135,10 +136,11 @@ std::string oc_to_string(const HandleMapTree& hmt, const std::string& indent)
 {
 	// TODO: show the hierarchy
 	std::stringstream ss;
-	ss << indent << "size = " << hmt.size() << std::endl;
+	ss << indent << "size = " << hmt.size();
 	unsigned i = 0;
 	for (HandleMapTree::iterator it = hmt.begin(); it != hmt.end(); ++it) {
-		ss << indent << "handle map[" << i << ",depth=" << hmt.depth(it) << "]:"
+		ss << std::endl << indent
+		   << "handle map[" << i << ",depth=" << hmt.depth(it) << "]:"
 		   << std::endl << oc_to_string(*it, indent + OC_TO_STRING_INDENT);
 		++i;
 	}
@@ -148,11 +150,11 @@ std::string oc_to_string(const HandleMapTree& hmt, const std::string& indent)
 std::string oc_to_string(const HandleHandleTreeMap& hhtm, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << indent << "size = " << hhtm.size() << std::endl;
+	ss << indent << "size = " << hhtm.size();
 	unsigned i = 0;
 	for (const auto& hht : hhtm) {
-		ss << indent << "atom[" << i << "]:" << std::endl
-		   << oc_to_string(hht.first, indent + OC_TO_STRING_INDENT);
+		ss << std::endl << indent << "atom[" << i << "]:" << std::endl
+		   << oc_to_string(hht.first, indent + OC_TO_STRING_INDENT) << std::endl;
 		ss << indent << "handle tree[" << i << "]:" << std::endl
 		   << oc_to_string(hht.second, indent + OC_TO_STRING_INDENT);
 		++i;

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -34,6 +34,7 @@
 #include <opencog/atoms/core/RewriteLink.h>
 #include <opencog/atoms/core/PresentLink.h>
 #include <opencog/atoms/core/VariableSet.h>
+#include <opencog/atoms/core/VariableList.h>
 #include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/core/TypeUtils.h>
@@ -47,6 +48,8 @@
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
 #include <boost/numeric/conversion/cast.hpp>
+#include <boost/algorithm/cxx11/all_of.hpp>
+#include <boost/algorithm/cxx11/any_of.hpp>
 
 namespace opencog
 {

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -284,53 +284,6 @@ Handle MinerUtils::compose(const Handle& pattern, const HandleMap& var2pat)
 	return pattern;
 }
 
-Handle MinerUtils::vardecl_compose(const Handle& vardecl, const HandleMap& var2subdecl)
-{
-	OC_ASSERT((bool)vardecl, "Not implemented");
-
-	Type t = vardecl->get_type();
-
-	// Base cases
-
-	if (t == VARIABLE_NODE) {
-		auto it = var2subdecl.find(vardecl);
-		// Compose if the variable maps to another variable
-		// declaration
-		if (it != var2subdecl.end())
-			return it->second;
-		return vardecl;
-	}
-
-	// Recursive cases
-
-	if (t == VARIABLE_LIST) {
-		HandleSeq oset;
-		for (const Handle& h : vardecl->getOutgoingSet()) {
-			Handle nh = vardecl_compose(h, var2subdecl);
-			if (nh) {
-				if (nh->get_type() == VARIABLE_LIST)
-					for (const Handle nhc : nh->getOutgoingSet())
-						oset.push_back(nhc);
-				else
-					oset.push_back(nh);
-			}
-		}
-
-		if (oset.empty())
-			return Handle::UNDEFINED;
-		if (oset.size() == 1)
-			return oset[0];
-		return createLink(oset, t);
-	}
-	else if (t == TYPED_VARIABLE_LINK) {
-		return vardecl_compose(vardecl->getOutgoingAtom(0), var2subdecl);
-	}
-	else {
-		OC_ASSERT(false, "Not implemented");
-		return Handle::UNDEFINED;
-	}
-}
-
 HandleSeq MinerUtils::get_db(const Handle& db_cpt)
 {
 	// Retrieve all members of db_cpt

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -1117,10 +1117,10 @@ std::string oc_to_string(const HandleSeqSeqSeq& hsss,
                          const std::string& indent)
 {
 	std::stringstream ss;
-	ss << indent << "size = " << hsss.size() << std::endl;
+	ss << indent << "size = " << hsss.size();
 	size_t i = 0;
 	for (const HandleSeqSeq& hss : hsss) {
-		ss << indent << "atoms sets[" << i << "]:" << std::endl
+		ss << std::endl << indent << "atoms sets[" << i << "]:" << std::endl
 		   << oc_to_string(hss, indent + oc_to_string_indent);
 		i++;
 	}

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -33,7 +33,7 @@
 #include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/atoms/core/RewriteLink.h>
 #include <opencog/atoms/core/PresentLink.h>
-#include <opencog/atoms/core/VariableList.h>
+#include <opencog/atoms/core/VariableSet.h>
 #include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/core/TypeUtils.h>
@@ -598,7 +598,7 @@ void MinerUtils::remove_useless_clauses(const Handle& vardecl, HandleSeq& clause
 void MinerUtils::remove_constant_clauses(const Handle& vardecl, HandleSeq& clauses)
 {
 	// Get Variables
-	VariableListPtr vl = createVariableList(vardecl);
+	VariableSetPtr vl = createVariableSet(vardecl);
 	const HandleSet& vars = vl->get_variables().varset;
 
 	// Remove constant clauses

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -67,7 +67,7 @@ public:
 	 *  {
 	 *    ;; Shallow abstractions of X
 	 *    { (Lambda
-	 *        (VariableList
+	 *        (VariableSet
 	 *          (Variable "$X1")
 	 *          (Variable "$X2"))
 	 *        (Inheritance
@@ -100,7 +100,7 @@ public:
 	 * ms = 2
 	 *
 	 * front_shallow_abstract(valuations) = { (Lambda
-	 *                                          (VariableList
+	 *                                          (VariableSet
 	 *                                            (Variable "$X1")
 	 *                                            (Variable "$X2"))
 	 *                                          (Inheritance
@@ -120,7 +120,7 @@ public:
 	 *
 	 * 1. itself if it is nullary (see is_nullary)
 	 *
-	 * 2. (Lambda (VariableList X1 ... Xn) (L X1 ... Xn) if it is a
+	 * 2. (Lambda (VariableSet X1 ... Xn) (L X1 ... Xn) if it is a
 	 *    link of arity n.
 	 *
 	 * For instance, with
@@ -128,7 +128,7 @@ public:
 	 * dt = (Inheritance (Concept "a") (Concept "b"))
 	 *
 	 * shallow_patterns(dt) = (Lambda
-	 *                          (VariableList
+	 *                          (VariableSet
 	 *                            (Variable "$X1")
 	 *                            (Variable "$X2"))
 	 *                          (Inheritance

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -27,9 +27,6 @@
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/unify/Unify.h>
 
-#include <boost/algorithm/cxx11/all_of.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
-
 #include "Valuations.h"
 
 namespace opencog
@@ -459,7 +456,7 @@ public:
 	                                        const Handle& var);
 
 	/**
-	 * List above but takes scope links instead of blocks (whether each
+	 * Like above but takes scope links instead of blocks (whether each
 	 * scope link has the conjunction of clauses of its block as body).
 	 *
 	 * TODO: for now, this code relies on unification. However it can

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -177,23 +177,6 @@ public:
 	static Handle compose(const Handle& pattern, const HandleMap& var2pat);
 
 	/**
-	 * TODO replace by RewriteLink::beta_reduce
-	 *
-	 * Given a variable declaration, and a mapping from variables to
-	 * variable declaration, produce a new variable declaration, as
-	 * obtained by compositing the pattern with the sub-patterns.
-	 *
-	 * If a variable in vardecl is missing in var2vardecl, then
-	 * vardecl is untouched. But if a variable maps to the undefined
-	 * Handle, then it is removed from the resulting variable
-	 * declaration. That happens in cases where the variable maps to a
-	 * constant pattern, i.e. a value. In such case composition
-	 * amounts to application.
-	 */
-	static Handle vardecl_compose(const Handle& vardecl,
-	                              const HandleMap& var2subdecl);
-
-	/**
 	 * Given a db concept node, retrieve all its members
 	 */
 	static HandleSeq get_db(const Handle& db_cpt);

--- a/opencog/miner/README.md
+++ b/opencog/miner/README.md
@@ -64,9 +64,10 @@ program that matches all atoms in the AtomSpace.
 
 As another example, a pattern matching only `Inheritance` links would
 look like
+
 ```scheme
 (Lambda
-  (VariableList
+  (VariableSet
     (Variable "$X")
     (Variable "$Y"))
   (Present
@@ -75,8 +76,19 @@ look like
       (Variable "$Y"))))
 ```
 
-Or, slightly more specialized, a pattern matching only `Inheritance`
-links with same first and second argument would look like
+Note: `VariableSet` can be used instead of `VariableList` when the
+order of the variables in the variable declaration is irrelevant.
+That is most certainly the case for the pattern miner as the only
+thing that matters in that application is the frequency of the
+pattern.  For that reason we strongly recommend to use `VariableSet`
+whenever possible, such as for instance in the definition of the
+initial pattern. Doing so is likely to speed up the search by many
+folds.
+
+Or, a slight specialization of the pattern above, matching only
+`Inheritance` links with the same first and second argument would look
+like
+
 ```scheme
 (Lambda
   (Variable "$X")
@@ -111,9 +123,10 @@ associated values produce matching data trees (or in order words data
 trees in the satisfying set of the pattern).
 
 For instance if `P` is
+
 ```scheme
 (Lambda
-  (VariableList
+  (VariableSet
     (Variable "$X")
     (Variable "$Y"))
   (Present
@@ -140,6 +153,7 @@ and `T` is
 ```
 
 then the satisfying set of `P` over `T` is
+
 ```scheme
 (Inheritance
   (Concept "A")
@@ -211,9 +225,10 @@ Another example, if the valuation set is the following singleton
 {(Variable "$X")->(Implication (Predicate "P") (Predicate "Q"))}
 ```
 its shallow abstraction over its single variable `(Variable "$X")` is
+
 ```scheme
 (Lambda
-  (VariableList
+  (VariableSet
     (Variable "$Z")
     (Variable "$W"))
   (Present
@@ -337,6 +352,7 @@ Given all specializations (6 in total in this iteration example), we
 now need to calculate the support of each of them against `T`, and
 only the one reaching the minimum support can be added back to the
 population of patterns `C`. Out of these 6 only one has enough support
+
 ```scheme
 (Lambda
   (Variable "$Y")
@@ -423,7 +439,7 @@ specialization. For instance the conjunction of the following patterns
 
 ```scheme
 (Lambda
-  (VariableList
+  (VariableSet
     (Variable "$X")
     (Variable "$Y"))
   (Present
@@ -434,7 +450,7 @@ specialization. For instance the conjunction of the following patterns
 
 ```scheme
 (Lambda
-  (VariableList
+  (VariableSet
     (Variable "$Y")
     (Variable "$Z"))
   (Present
@@ -447,8 +463,9 @@ using `(Variable "$Y")` as connector, result into
 
 ```scheme
 (Lambda
-  (VariableList
+  (VariableSet
     (Variable "$X")
+    (Variable "$Y"))
     (Variable "$Z"))
   (Present
     (Inheritance
@@ -616,15 +633,18 @@ Usage
 
 To invoke the pattern miner, within guile, you first need to import
 the `miner` module
+
 ```scheme
 (use-modules (opencog miner))
 ```
 
 Then, simply call `cog-mine` on your database with a given minimum
 support
+
 ```scheme
 (cog-mine db #:minsup ms)
 ```
+
 where `db` is either
 1. a Scheme list of atoms
 2. an Atomese List or Set of atoms
@@ -635,12 +655,14 @@ where `db` is either
 `cog-mine` automatically configures the rule engine, calls it, returns
 its results and removes the atoms that were temporarily created. The
 results have the following form
+
 ```scheme
 (Set
   P1
   ...
   Pn)
 ```
+
 where `P1` to `Pn` are the patterns discovered by the pattern miner.
 
 In addition `cog-mine` accepts multiple options such as

--- a/opencog/miner/Valuations.cc
+++ b/opencog/miner/Valuations.cc
@@ -144,9 +144,9 @@ std::string SCValuations::to_string(const std::string& indent) const
 {
 	std::stringstream ss;
 	ss << indent << "variables:" << std::endl
-	   << oc_to_string(variables, indent + OC_TO_STRING_INDENT)
+	   << oc_to_string(variables, indent + OC_TO_STRING_INDENT) << std::endl
 		<< indent << "valuations:" << std::endl
-	   << oc_to_string(valuations, indent + OC_TO_STRING_INDENT)
+		<< oc_to_string(valuations, indent + OC_TO_STRING_INDENT) << std::endl
 	   << indent << "_var_idx = " << _var_idx;
 	return ss.str();
 }
@@ -241,7 +241,7 @@ std::string Valuations::to_string(const std::string& indent) const
 	std::stringstream ss;
 	ss << indent << "size = " << size() << std::endl
 		<< indent << "variables:" << std::endl
-	   << oc_to_string(variables, indent + OC_TO_STRING_INDENT)
+	   << oc_to_string(variables, indent + OC_TO_STRING_INDENT) << std::endl
 	   << indent << "scvaluations set:" << std::endl
 	   << oc_to_string(scvs, indent + OC_TO_STRING_INDENT) << std::endl
 	   << indent << "_var_idx = " << _var_idx;

--- a/opencog/miner/miner-utils.scm
+++ b/opencog/miner/miner-utils.scm
@@ -477,7 +477,7 @@
   For instance (conjunct-pattern 3), creates
 
   (Lambda
-    (VariableList
+    (VariableSet
       (Variable \"$X-1\")
       (Variable \"$X-2\")
       (Variable \"$X-3\"))
@@ -487,7 +487,7 @@
       (Variable \"$X-3\")))
 "
   (let* ((vars (gen-variables "$X" nconj))
-         (var-lst (VariableList vars))
+         (var-lst (VariableSet vars))
          (var-conj (Present vars)))
     (Lambda var-lst var-conj)))
 

--- a/opencog/miner/rules/conjunction-expansion.scm
+++ b/opencog/miner/rules/conjunction-expansion.scm
@@ -24,7 +24,7 @@
 ;;   Predicate "minsup"
 ;;   List
 ;;     Lambda
-;;       VariableList
+;;       VariableSet
 ;;         <f-vardecl>
 ;;         <g-vardecl>
 ;;       And
@@ -38,7 +38,7 @@
 ;; variables are properly alpha-converted to avoid any variable name
 ;; collision. Finally,
 ;;
-;; VariableList
+;; VariableSet
 ;;   <f-vardecl>
 ;;   <g-vardecl>
 ;;
@@ -112,7 +112,7 @@
              (f (Quote (Lambda (Unquote f-vardecl) (Unquote f-body))))
              (minsup-f (minsup-eval f db ms)))
         (Bind
-          (VariableList
+          (VariableSet
             f-vardecl-decl
             g-vardecl-decl
             f-body-decl
@@ -153,7 +153,7 @@
                                (Present (map Unquote f-conjuncts)))))
              (minsup-f (minsup-eval f db ms)))
       (Bind
-        (VariableList
+        (VariableSet
           f-vardecl-decl
           g-vardecl-decl
           f-conjuncts-decls

--- a/opencog/miner/rules/emp.scm
+++ b/opencog/miner/rules/emp.scm
@@ -37,7 +37,7 @@
          ;; Clauses
          (minsup-pattern (minsup-eval pattern db ms)))
   (Bind
-    (VariableList
+    (VariableSet
       pattern-decl
       db-decl
       ms-decl)

--- a/opencog/miner/rules/est.scm
+++ b/opencog/miner/rules/est.scm
@@ -43,7 +43,7 @@
          ;; Clauses
          (minsup-pattern (minsup-eval pattern db ms)))
   (Bind
-    (VariableList
+    (VariableSet
       pattern-decl
       db-decl
       ms-decl)

--- a/opencog/miner/rules/i-surprisingness.scm
+++ b/opencog/miner/rules/i-surprisingness.scm
@@ -48,8 +48,9 @@
   (define ms (Variable "$ms"))
   ;; Types
   (define VariableT (Type "VariableNode"))
+  (define VariableSetT (Type "VariableSet"))
   (define VariableListT (Type "VariableList"))
-  (define varT (TypeChoice VariableT VariableListT))
+  (define varT (TypeChoice VariableT VariableSetT VariableListT))
   (define NumberT (Type "NumberNode"))
   (define ConceptT (Type "ConceptNode"))
   ;; Typed declations
@@ -70,7 +71,7 @@
              (f-minsup (minsup-eval f db ms))
              (f-isurp (surp-eval mode f db)))
         (Bind
-          (VariableList
+          (VariableSet
             typed-f-vardecl
             cnj-bodies
             typed-db

--- a/opencog/miner/rules/jsd-surprisingness.scm
+++ b/opencog/miner/rules/jsd-surprisingness.scm
@@ -35,8 +35,9 @@
   (define ms (Variable "$ms"))
   ;; Types
   (define VariableT (Type "VariableNode"))
+  (define VariableSetT (Type "VariableSet"))
   (define VariableListT (Type "VariableList"))
-  (define varT (TypeChoice VariableT VariableListT))
+  (define varT (TypeChoice VariableT VariableSetT VariableListT))
   (define NumberT (Type "NumberNode"))
   (define ConceptT (Type "ConceptNode"))
   ;; Typed declations
@@ -55,7 +56,7 @@
              (jsd-e (jsd-eval f db))
              (surp-e (surp-eval 'jsdsurp f db)))
         (Bind
-          (VariableList
+          (VariableSet
             typed-f-vardecl
             cnj-bodies
             typed-db

--- a/opencog/miner/rules/jsd.scm
+++ b/opencog/miner/rules/jsd.scm
@@ -37,7 +37,7 @@
          (emp (emp-eval pattern db))
          (est (est-eval pattern db)))
   (Bind
-    (VariableList
+    (VariableSet
       pattern-decl
       db-decl)
     (And

--- a/opencog/miner/rules/shallow-abstraction.scm
+++ b/opencog/miner/rules/shallow-abstraction.scm
@@ -9,7 +9,7 @@
 ;;   Predicate "minsup"
 ;;   List
 ;;     Lambda
-;;       VariableList
+;;       VariableSet
 ;;         <x1>
 ;;         ...
 ;;         <xn>
@@ -30,7 +30,7 @@
 ;;         Predicate "minsup"
 ;;         List
 ;;           Lambda
-;;             VariableList
+;;             VariableSet
 ;;               <x1>
 ;;               ...
 ;;               <xn>
@@ -67,7 +67,7 @@
          ;; Clauses
          (minsup-g (minsup-eval g db ms)))
   (Bind
-    (VariableList
+    (VariableSet
       g-decl
       db-decl
       ms-decl)

--- a/opencog/miner/rules/shallow-specialization.scm
+++ b/opencog/miner/rules/shallow-specialization.scm
@@ -60,7 +60,7 @@
          ;; Clauses
          (minsup-pattern (minsup-eval pattern db ms)))
   (Bind
-    (VariableList
+    (VariableSet
       pattern-decl
       db-decl
       ms-decl)

--- a/opencog/miner/rules/specialization.scm
+++ b/opencog/miner/rules/specialization.scm
@@ -14,7 +14,7 @@
 ;;   Predicate "minsup"
 ;;   List
 ;;     Lambda
-;;       VariableList
+;;       VariableSet
 ;;         <x1>
 ;;         ...
 ;;         <xn>
@@ -39,7 +39,7 @@
 ;;   List
 ;;     Put
 ;;       Lambda
-;;         VariableList
+;;         VariableSet
 ;;           <x1>
 ;;           ...
 ;;           <xn>
@@ -92,7 +92,7 @@
          (db-decl (TypedVariable db ConceptT))
          (ms-decl (TypedVariable ms NumberT))
          (xs-f-decl xs-f)
-         (vardecl (VariableList g-decl db-decl ms-decl xs-f-decl))
+         (vardecl (VariableSet g-decl db-decl ms-decl xs-f-decl))
          ;; Clauses
          (minsup-g (minsup-eval g db ms))
          (shabs-eval (abstraction-eval xs-f minsup-g))

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -96,7 +96,7 @@ private:
 	 * Make
 	 *
 	 * (Lambda
-	 *   (VariableList X1 ... Xn)
+	 *   (VariableSet X1 ... Xn)
 	 *   (Present X1 ... Xn))
 	 */
 	Handle mk_nconjunct(unsigned n);
@@ -143,14 +143,14 @@ public:
 
 	// Auxiliary methods
 	void test_partitions();
-	void test_is_syntax_more_abstract_1();
-	void test_is_syntax_more_abstract_2();
-	void test_is_syntax_more_abstract_3();
-	void test_is_more_abstract_1();
-	void test_is_more_abstract_2();
-	void test_is_more_abstract_3();
-	// TODO: fix is_more_abstract to support that case
-	void xtest_is_more_abstract_4();
+	void test_is_blk_syntax_more_abstract_1();
+	void test_is_blk_syntax_more_abstract_2();
+	void test_is_blk_syntax_more_abstract_3();
+	void test_is_pat_syntax_more_abstract();
+	void test_is_pat_more_abstract_1();
+	void test_is_pat_more_abstract_2();
+	void test_is_pat_more_abstract_3();
+	void xtest_is_pat_more_abstract_4(); // TODO: fix is_pat_more_abstract
 	void test_is_more_abstract_foreach_var();
 	void test_remove_useless_clauses_1();
 	void test_remove_useless_clauses_2();
@@ -351,7 +351,7 @@ void MinerUTest::test_partitions()
 	TS_ASSERT_EQUALS(result, expect);
 }
 
-void MinerUTest::test_is_syntax_more_abstract_1()
+void MinerUTest::test_is_blk_syntax_more_abstract_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -363,7 +363,7 @@ void MinerUTest::test_is_syntax_more_abstract_1()
 	TS_ASSERT(not MinerUtils::is_blk_syntax_more_abstract(l_blk, r_blk, Y));
 }
 
-void MinerUTest::test_is_syntax_more_abstract_2()
+void MinerUTest::test_is_blk_syntax_more_abstract_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -375,7 +375,7 @@ void MinerUTest::test_is_syntax_more_abstract_2()
 	TS_ASSERT(MinerUtils::is_blk_syntax_more_abstract(l_blk, r_blk, Y));
 }
 
-void MinerUTest::test_is_syntax_more_abstract_3()
+void MinerUTest::test_is_blk_syntax_more_abstract_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -389,13 +389,25 @@ void MinerUTest::test_is_syntax_more_abstract_3()
 	TS_ASSERT(not MinerUtils::is_blk_syntax_more_abstract(r_blk, l_blk, X));
 }
 
+void MinerUTest::test_is_pat_syntax_more_abstract()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-void MinerUTest::test_is_more_abstract_1()
+	Handle
+		clause1 = al(EVALUATION_LINK, X, Y),
+		clause2 = al(EVALUATION_LINK, X, al(LIST_LINK, Z, A)),
+		pat1 = MinerUtils::mk_pattern_no_vardecl({clause1}),
+		pat2 = MinerUtils::mk_pattern_no_vardecl({clause2});
+
+	TS_ASSERT(MinerUtils::is_pat_syntax_more_abstract(pat1, pat2, X));
+}
+
+void MinerUTest::test_is_pat_more_abstract_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	Handle l_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(VARIABLE_SET, X, Y, Z),
 	                  al(PRESENT_LINK,
 	                     al(INHERITANCE_LINK, X, Z),
 	                     al(INHERITANCE_LINK, Y, Z)));
@@ -407,15 +419,15 @@ void MinerUTest::test_is_more_abstract_1()
 	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, Z));
 }
 
-void MinerUTest::test_is_more_abstract_2()
+void MinerUTest::test_is_pat_more_abstract_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	Handle l_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y),
+	                  al(VARIABLE_SET, X, Y),
 	                  al(INHERITANCE_LINK, X, Z));
 	Handle r_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(VARIABLE_SET, X, Y, Z),
 	                  al(PRESENT_LINK,
 	                     al(INHERITANCE_LINK, X, C0),
 	                     al(INHERITANCE_LINK, Z, Y),
@@ -425,17 +437,17 @@ void MinerUTest::test_is_more_abstract_2()
 	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, X));
 }
 
-void MinerUTest::test_is_more_abstract_3()
+void MinerUTest::test_is_pat_more_abstract_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	Handle l_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(VARIABLE_SET, X, Y, Z),
 	                  al(PRESENT_LINK,
 	                     al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Z, C1)));
 	Handle r_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Z),
+	                  al(VARIABLE_SET, X, Z),
 	                  al(PRESENT_LINK,
 	                     al(INHERITANCE_LINK, X, C0),
 	                     al(INHERITANCE_LINK, Z, Y)));
@@ -447,16 +459,16 @@ void MinerUTest::test_is_more_abstract_3()
 	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, Y));
 }
 
-void MinerUTest::xtest_is_more_abstract_4()
+void MinerUTest::xtest_is_pat_more_abstract_4()
 {
 	Handle l_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Y, Z),
+	                  al(VARIABLE_SET, X, Y, Z),
 	                  al(PRESENT_LINK,
 	                     al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Z, Y)));
 	// TODO: this seems bogus, X is not even in the body
 	Handle r_pat = al(LAMBDA_LINK,
-	                  al(VARIABLE_LIST, X, Z),
+	                  al(VARIABLE_SET, X, Z),
 	                  al(INHERITANCE_LINK, Z, C0));
 
 	// Left pattern is more abstract than right pattern, relative to X.
@@ -466,7 +478,7 @@ void MinerUTest::xtest_is_more_abstract_4()
 	TS_ASSERT(MinerUtils::is_pat_more_abstract(l_pat, r_pat, Y));
 }
 
-void MinerUTest:: test_is_more_abstract_foreach_var()
+void MinerUTest::test_is_more_abstract_foreach_var()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -511,7 +523,7 @@ void MinerUTest:: test_remove_useless_clauses_2()
 	// does not introduce new variables, therefore it is redundant and
 	// can be removed.
 	Handle
-		vardecl = al(VARIABLE_LIST, X, Y),
+		vardecl = al(VARIABLE_SET, X, Y),
 		clause1 = al(INHERITANCE_LINK, X, C1),
 		clause2 = al(INHERITANCE_LINK, C2, Y),
 		clause3 = al(INHERITANCE_LINK, X, Y),
@@ -553,7 +565,7 @@ void MinerUTest:: test_remove_useless_clauses_3()
 	// No clause is more abstract than the others, thus nothing should
 	// be removed.
 	Handle
-		vardecl = al(VARIABLE_LIST, X, Y, Z, W),
+		vardecl = al(VARIABLE_SET, X, Y, Z, W),
 		clause1 = al(INHERITANCE_LINK, X, Y),
 		clause2 = al(INHERITANCE_LINK, Y, Z),
 		clause3 = al(INHERITANCE_LINK, Z, W),
@@ -576,7 +588,7 @@ void MinerUTest::test_compose_1()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	Handle InhYB = al(INHERITANCE_LINK, Y, B),
-		pattern = MinerUtils::mk_pattern(al(VARIABLE_LIST, X, Y), {X, InhYB}),
+		pattern = MinerUtils::mk_pattern(al(VARIABLE_SET, X, Y), {X, InhYB}),
 		subpat = A;
 
 	Handle npat = MinerUtils::compose(pattern, {{Y, subpat}}),
@@ -592,7 +604,7 @@ void MinerUTest::test_compose_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle VarXY = al(VARIABLE_LIST, X, Y),
+	Handle VarXY = al(VARIABLE_SET, X, Y),
 		pattern = al(LAMBDA_LINK,
 		             VarXY,
 		             al(PRESENT_LINK,
@@ -685,7 +697,7 @@ void MinerUTest::test_expand_conjunction_1()
 	HandleSeq db{InhAB, InhBC};
 
 	Handle InhXY = al(INHERITANCE_LINK, X, Y),
-		VarXY = al(VARIABLE_LIST, X, Y),
+		VarXY = al(VARIABLE_SET, X, Y),
 		p1 = al(LAMBDA_LINK,
 		        VarXY,
 		        al(AND_LINK, InhXY, InhXY)),
@@ -741,7 +753,7 @@ void MinerUTest::test_expand_conjunction_3()
 	HandleSeq db{InhAB, InhBC};
 
 	Handle InhXY = al(INHERITANCE_LINK, X, Y),
-		VarXY = al(VARIABLE_LIST, X, Y),
+		VarXY = al(VARIABLE_SET, X, Y),
 		pat = MinerUtils::mk_pattern(VarXY, {InhXY});
 
 	HandleSet results = MinerUtils::expand_conjunction(pat, pat, db, 1,
@@ -751,8 +763,8 @@ void MinerUTest::test_expand_conjunction_3()
 		InhZX = al(INHERITANCE_LINK, Z, X),
 		InhYW = al(INHERITANCE_LINK, Y, W),
 		InhZY = al(INHERITANCE_LINK, Z, Y),
-		VarXYW = al(VARIABLE_LIST, X, Y, W),
-		VarXYZ = al(VARIABLE_LIST, X, Y, Z),
+		VarXYW = al(VARIABLE_SET, X, Y, W),
+		VarXYZ = al(VARIABLE_SET, X, Y, Z),
 		InhXYXW = MinerUtils::mk_pattern(VarXYW, {InhXY, InhXW}),
 		InhXYZX = MinerUtils::mk_pattern(VarXYZ, {InhXY, InhZX}),
 		InhXYYW = MinerUtils::mk_pattern(VarXYW, {InhXY, InhYW}),
@@ -783,7 +795,7 @@ void MinerUTest::test_expand_conjunction_4()
 
 	Handle InhXY = al(INHERITANCE_LINK, X, Y),
 		LstXY = al(LIST_LINK, X, Y),
-		VarXY = al(VARIABLE_LIST, X, Y),
+		VarXY = al(VARIABLE_SET, X, Y),
 		p1 = al(LAMBDA_LINK,
 		        VarXY,
 		        InhXY),
@@ -798,7 +810,7 @@ void MinerUTest::test_expand_conjunction_4()
 		InhZY = al(INHERITANCE_LINK, Z, Y),
 		LstXZ = al(LIST_LINK, X, Z),
 		LstZY = al(LIST_LINK, Z, Y),
-		VarXYZ = al(VARIABLE_LIST, X, Y, Z),
+		VarXYZ = al(VARIABLE_SET, X, Y, Z),
 		InhXYLstXZ = MinerUtils::mk_pattern(VarXYZ,
 		                                    {InhXY, LstXZ}),
 		InhXYLstZY = MinerUtils::mk_pattern(VarXYZ,
@@ -823,7 +835,7 @@ void MinerUTest::test_shallow_abstract()
 	logger().debug() << "rs = " << rs;
 
 	// Define pattern
-	Handle VarXZW = al(VARIABLE_LIST, X, Z, W),
+	Handle VarXZW = al(VARIABLE_SET, X, Z, W),
 		ugly = an(CONCEPT_NODE, "ugly");
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, ugly),
 	                     al(INHERITANCE_LINK, X, Z),
@@ -857,9 +869,13 @@ void MinerUTest::test_shallow_abstract()
 		man = an(CONCEPT_NODE, "man"),
 		soda_drinker = an(CONCEPT_NODE, "soda drinker"),
 		woman = an(CONCEPT_NODE, "woman");
-	HandleSetSeq expect{ { Abe, Alaura, Allen, Cason, Davion,
+	// Expected shallow abstractions
+	HandleSetSeq expect{ // Values for X
+	                     { Abe, Alaura, Allen, Cason, Davion,
 	                       Emily, Hessley, Lily, Lucy, Sophia },
-	                     { soda_drinker, W, ugly, man, human, woman },
+	                     // Values for W. Z comes from variable factorization.
+	                     { soda_drinker, Z, ugly, man, human, woman },
+	                     // Values for Z. No variable factorization as last one.
 	                     { soda_drinker, ugly, man, human, woman } };
 
 	logger().debug() << "result = " << oc_to_string(result);
@@ -872,6 +888,8 @@ void MinerUTest::test_A()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
+	// Test db size < minsup, thus expected result should be empty
+
 	// Run C++ pattern miner
 	HandleTree cpp_results = cpp_pm({A}, 2),
 		cpp_expected;
@@ -882,8 +900,7 @@ void MinerUTest::test_A()
 	TS_ASSERT(content_eq(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm({A}, 2, 10), // TODO remove max_iter
-	                                         // when possible
+	Handle ure_results = ure_pm({A}, 2),
 		ure_expected = al(SET_LINK);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
@@ -910,7 +927,7 @@ void MinerUTest::test_AB()
 	TS_ASSERT(content_eq(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm({A, B}, 2, 10),
+	Handle ure_results = ure_pm({A, B}, 2),
 		ure_expected = mk_minsup_evals(2, {top});
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
@@ -927,7 +944,7 @@ void MinerUTest::test_AB_redundant_cnj()
 	// solution set does not contain
 	//
 	// (LambdaLink
-	//   (VariableList
+	//   (VariableSet
 	//     (VariableNode "$X")
 	//     (VariableNode "$Y")
 	//   )
@@ -980,13 +997,13 @@ void MinerUTest::test_AB_AC()
 	HandleSeq db{InhAB, InhAC};
 
 	// Define pattern parts
-	Handle VarXY = al(VARIABLE_LIST, X, Y),
+	Handle VarXY = al(VARIABLE_SET, X, Y),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhAY = al(INHERITANCE_LINK, A, Y);
 
 	// Run URE pattern miner (using _as for testing more diverse
 	// content)
-	Handle ure_results = ure_pm(_as, 2, 10),
+	Handle ure_results = ure_pm(_as, 2),
 		expected_pattern = MinerUtils::mk_pattern(Y, {InhAY}),
 		ure_expected = mk_minsup_eval(2, expected_pattern);
 
@@ -1348,7 +1365,7 @@ void MinerUTest::test_2conjuncts_1()
 	HandleSeq db{InhAB, InhBC1, InhBC2};
 
 	// Define pattern parts
-	Handle VarXY = al(VARIABLE_LIST, X, Y),
+	Handle VarXY = al(VARIABLE_SET, X, Y),
 		InhXA = al(INHERITANCE_LINK, X, A),
 		InhAY = al(INHERITANCE_LINK, A, Y);
 
@@ -1381,8 +1398,8 @@ void MinerUTest::test_2conjuncts_2()
 	HandleSeq db{AB, BC1, BC2};
 
 	// Define pattern parts
-	Handle VarXYZ = al(VARIABLE_LIST, X, Y, Z),
-		VarXYZW = al(VARIABLE_LIST, X, Y, Z, W),
+	Handle VarXYZ = al(VARIABLE_SET, X, Y, Z),
+		VarXYZW = al(VARIABLE_SET, X, Y, Z, W),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhYZ = al(INHERITANCE_LINK, Y, Z),
 		InhZW = al(INHERITANCE_LINK, Z, W);
@@ -1499,8 +1516,8 @@ void MinerUTest::test_2conjuncts_5()
 	HandleSeq db{InhA1B, InhA2B, InhBC1, InhBC2};
 
 	// Define pattern parts
-	Handle VarXYZ = al(VARIABLE_LIST, X, Y, Z),
-		VarXYZW = al(VARIABLE_LIST, X, Y, Z, W),
+	Handle VarXYZ = al(VARIABLE_SET, X, Y, Z),
+		VarXYZW = al(VARIABLE_SET, X, Y, Z, W),
 		InhXY = al(INHERITANCE_LINK, X, Y),
 		InhYZ = al(INHERITANCE_LINK, Y, Z),
 		InhZW = al(INHERITANCE_LINK, Z, W);
@@ -1539,7 +1556,7 @@ void MinerUTest::test_InferenceControl()
 	// Define initpat
 	//
 	// Lambda
-	//   VariableList
+	//   VariableSet
 	//     Variable "$T"
 	//     Variable "$A"
 	//     Variable "$L"
@@ -1572,7 +1589,7 @@ void MinerUTest::test_InferenceControl()
 		VarA = an(VARIABLE_NODE, "$A"),
 		VarL = an(VARIABLE_NODE, "$L"),
 		VarB = an(VARIABLE_NODE, "$B"),
-		vardecl = al(VARIABLE_LIST, VarT, VarA, VarL, VarB);
+		vardecl = al(VARIABLE_SET, VarT, VarA, VarL, VarB);
 	HandleSeq clauses = {al(EXECUTION_LINK,
 	                        expand,
 	                        al(LIST_LINK, VarA, VarL, de_rule),
@@ -1588,11 +1605,11 @@ void MinerUTest::test_InferenceControl()
 	// The pattern of interest looks like
 	//
 	// Lambda
-	//   VariableList
-	//   Variable "$T"
-	//   Variable "$A"
-	//   Variable "$X"
-	//   Variable "$B"
+	//   VariableSet
+	//     Variable "$T"
+	//     Variable "$A"
+	//     Variable "$X"
+	//     Variable "$B"
 	// And
 	//   Execution
 	//     Schema "expand"
@@ -1615,7 +1632,7 @@ void MinerUTest::test_InferenceControl()
 	//       Variable "$B"
 	//       Variable "$T"
 	Handle a = an(CONCEPT_NODE, "a"),
-		expected_vardecl = al(VARIABLE_LIST, VarT, VarA, X, VarB);
+		expected_vardecl = al(VARIABLE_SET, VarT, VarA, X, VarB);
 	HandleSeq
 		expected_clauses = {al(EXECUTION_LINK,
 		                       expand,
@@ -1663,7 +1680,7 @@ void MinerUTest::test_SodaDrinker()
 	logger().debug() << "rs = " << rs;
 
 	// Define initial pattern (to speed up mining)
-	Handle VarXYZW = al(VARIABLE_LIST, X, Y, Z, W);
+	Handle VarXYZW = al(VARIABLE_SET, X, Y, Z, W);
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, X, Z),
 	                     al(INHERITANCE_LINK, X, W)};
@@ -1697,7 +1714,7 @@ void MinerUTest::test_SodaDrinker()
 	TS_ASSERT(content_is_in(expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(_tmp_as, 5, 100, initpat),
+	Handle ure_results = ure_pm(_tmp_as, 5, 500, initpat),
 		ure_expected = mk_minsup_eval(5, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
@@ -1792,7 +1809,7 @@ void MinerUTest::xtest_lojban()
 		X1 = tmp_an(VARIABLE_NODE, "$X1"),
 		X2 = tmp_an(VARIABLE_NODE, "$X2"),
 		Z2 = tmp_an(VARIABLE_NODE, "$Z2"),
-		VARS = tmp_al(VARIABLE_LIST, X1, X2, Z2, P1, P3);
+		VARS = tmp_al(VARIABLE_SET, X1, X2, Z2, P1, P3);
 	HandleSeq clauses = { tmp_al(EVALUATION_LINK, P1, tmp_al(LIST_LINK, X1, X2)),
 	                      tmp_al(EVALUATION_LINK, P3, tmp_al(LIST_LINK, X1, Z2)) };
 	Handle initpat = MinerUtils::mk_pattern(VARS, clauses);
@@ -1848,14 +1865,14 @@ void MinerUTest::test_vqa()
 	// Start from (Member X Y), conjunctions will be grown
 	// incrementally.
 	Handle
-		VarXY = al(VARIABLE_LIST, X, Y),
+		VarXY = al(VARIABLE_SET, X, Y),
 		MemXY = al(MEMBER_LINK, X, Y),
 		initpat = MinerUtils::mk_pattern(VarXY, {MemXY});
 
 	// The pattern of interest looks like
 	//
 	// (LambdaLink
-	//   (VariableList
+	//   (VariableSet
 	//     (VariableNode "$PM-24b2cd09")
 	//     (VariableNode "$PM-1b1cc2ca")
 	//     (VariableNode "$PM-24b2cd09-1de71072")
@@ -1874,11 +1891,11 @@ void MinerUTest::test_vqa()
 	//
 	// TODO: find a better pattern of interest
 	Handle
-		VarXYZ = al(VARIABLE_LIST, X, Y, Z),
+		VarXYZ = al(VARIABLE_SET, X, Y, Z),
 		MemZY = al(MEMBER_LINK, Z, Y),
-		expected = MinerUtils::mk_pattern(VarXYZ, {MemXY, MemZY});
+		expect_pat = MinerUtils::mk_pattern(VarXYZ, {MemXY, MemZY});
 
-	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "expect_pat = " << oc_to_string(expect_pat);
 
 	// Run URE pattern miner
 	bool conjunction_expansion = true;
@@ -1897,7 +1914,7 @@ void MinerUTest::test_vqa()
 	                        max_cnjexp_variables,
 	                        enforce_specialization,
 	                        complexity_penalty),
-		expect = mk_minsup_eval(minsup, expected);
+		expect = mk_minsup_eval(minsup, expect_pat);
 
 	logger().debug() << "results = " << oc_to_string(results->getOutgoingSet());
 	logger().debug() << "expect = " << oc_to_string(expect);

--- a/tests/miner/SurprisingnessUTest.cxxtest
+++ b/tests/miner/SurprisingnessUTest.cxxtest
@@ -206,7 +206,7 @@ SurprisingnessUTest::SurprisingnessUTest() : _scm(&_as)
 	randGen().seed(0);
 
 	// Main logger
-	logger().set_level(Logger::DEBUG);
+	logger().set_level(Logger::INFO);
 	logger().set_timestamp_flag(false);
 	logger().set_sync_flag(true);
 	logger().set_print_to_stdout_flag(true);

--- a/tests/miner/SurprisingnessUTest.cxxtest
+++ b/tests/miner/SurprisingnessUTest.cxxtest
@@ -313,7 +313,7 @@ void SurprisingnessUTest::test_emp_prob_bs_1()
 	//     X
 	//     Y
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y),
+	                    al(VARIABLE_SET, X, Y),
 	                    al(INHERITANCE_LINK, X, Y));
 
 	HandleSeq db = MinerUtils::get_db(_db_cpt);
@@ -345,7 +345,7 @@ void SurprisingnessUTest::test_emp_prob_bs_2()
 	//       Z
 	//       Y
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z),
+	                    al(VARIABLE_SET, X, Y, Z),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Y, Z)));
@@ -353,9 +353,9 @@ void SurprisingnessUTest::test_emp_prob_bs_2()
 	HandleSeq db = MinerUtils::get_db(_db_cpt);
 	double epr = Surprisingness::emp_prob(pattern, db);
 	double epr_bs = Surprisingness::emp_prob_bs(pattern, db, 100, 1500);
-	logger().info() << "db.size() = " << db.size()
-	                << ", epr = " << epr
-	                << ", epr_bs = " << epr_bs;
+	logger().debug() << "db.size() = " << db.size()
+	                 << ", epr = " << epr
+	                 << ", epr_bs = " << epr_bs;
 	TS_ASSERT_DELTA(epr, epr_bs, 0.001);
 }
 
@@ -630,7 +630,7 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_1()
 	//     Inheritance X Y
 	//     Inheritance Z W
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z, W),
+	                    al(VARIABLE_SET, X, Y, Z, W),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Z, W)));
@@ -685,7 +685,7 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_2()
 	//     Inheritance X C0
 	//     Inheritance Y C1
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y),
+	                    al(VARIABLE_SET, X, Y),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, C0),
 	                       al(INHERITANCE_LINK, Y, C1)));
@@ -734,6 +734,8 @@ void SurprisingnessUTest::test_nisurp_no_linkage_synthetic_2()
 	// values of each variable, which is hard to guess.
 void SurprisingnessUTest::test_nisurp_linkage_synthetic_1()
 {
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
 	// Create data base
 	populate_uniform_inheritance_links(3, 0.8);
 
@@ -796,7 +798,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_2()
 	//     Inheritance X Y
 	//     Inheritance Y Z
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z),
+	                    al(VARIABLE_SET, X, Y, Z),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Y, Z)));
@@ -824,7 +826,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_2()
 // Similar to above for pattern
 //
 // LambdaLink
-//   VariableList
+//   VariableSet
 //     X
 //     Y
 //     Z
@@ -860,7 +862,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 	//       Z
 	//       Y
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z),
+	                    al(VARIABLE_SET, X, Y, Z),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Z, Y)));
@@ -888,7 +890,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 // Similar to above for pattern
 //
 // LambdaLink
-//   VariableList
+//   VariableSet
 //     X
 //     Y
 //   PresentLink
@@ -922,7 +924,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 	//       C0
 	//       Y
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y),
+	                    al(VARIABLE_SET, X, Y),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, C0, Y)));
@@ -950,7 +952,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_4()
 // Similar to above for pattern
 //
 // LambdaLink
-//   VariableList
+//   VariableSet
 //     X
 //     Y
 //     Z
@@ -986,7 +988,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_5()
 	//       W
 	//       Y
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z, W),
+	                    al(VARIABLE_SET, X, Y, Z, W),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Z, Y),
@@ -1015,7 +1017,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_5()
 // Similar to above for pattern
 //
 // LambdaLink
-//   VariableList
+//   VariableSet
 //     X
 //     Y
 //     Z
@@ -1042,7 +1044,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 	// Create pattern to measure surprisingness of
 	//
 	// LambdaLink
-	//   VariableList
+	//   VariableSet
 	//     X
 	//     Y
 	//     Z
@@ -1060,7 +1062,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 	//       Z
 	//       C1
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z),
+	                    al(VARIABLE_SET, X, Y, Z),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Z, Y),
@@ -1090,7 +1092,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 // Similar to above for pattern
 //
 // LambdaLink
-//   VariableList
+//   VariableSet
 //     X
 //     Y
 //     Z
@@ -1125,7 +1127,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_7()
 	//       Y
 	//       Z
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z, W),
+	                    al(VARIABLE_SET, X, Y, Z, W),
 	                    al(PRESENT_LINK,
 	                       al(LIST_LINK, X, Y, Z),
 	                       al(LIST_LINK, W, Y, Z)));
@@ -1153,7 +1155,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_7()
 // Similar to above for pattern
 //
 // LambdaLink
-//   VariableList
+//   VariableSet
 //     X
 //     Y
 //     Z
@@ -1188,7 +1190,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_8()
 	//       W
 	//       X
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z, W),
+	                    al(VARIABLE_SET, X, Y, Z, W),
 	                    al(PRESENT_LINK,
 	                       al(LIST_LINK, X, Y, X),
 	                       al(LIST_LINK, Z, W, X)));
@@ -1234,7 +1236,7 @@ void SurprisingnessUTest::test_nisurp_emp_prob_bs_1()
 	//       Z
 	//       Y
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z),
+	                    al(VARIABLE_SET, X, Y, Z),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Z, Y)));
@@ -1306,7 +1308,7 @@ void SurprisingnessUTest::test_nisurp_ugly_man_soda_drinker()
 	//       W
 	//       Y
 	Handle linkage_pattern = al(LAMBDA_LINK,
-	                            al(VARIABLE_LIST, X, Y, Z, W),
+	                            al(VARIABLE_SET, X, Y, Z, W),
 	                            al(PRESENT_LINK,
 	                               al(INHERITANCE_LINK, X, Y),
 	                               al(INHERITANCE_LINK, Z, Y),
@@ -1350,7 +1352,7 @@ void SurprisingnessUTest::test_jsdsurp_no_linkage_synthetic()
 	//     Inheritance X Y
 	//     Inheritance Z W
 	Handle pattern = al(LAMBDA_LINK,
-	                    al(VARIABLE_LIST, X, Y, Z, W),
+	                    al(VARIABLE_SET, X, Y, Z, W),
 	                    al(PRESENT_LINK,
 	                       al(INHERITANCE_LINK, X, Y),
 	                       al(INHERITANCE_LINK, Z, W)));
@@ -1426,7 +1428,7 @@ void SurprisingnessUTest::test_jsdsurp_ugly_man_soda_drinker()
 	//       W
 	//       Y
 	Handle linkage_pattern = al(LAMBDA_LINK,
-	                            al(VARIABLE_LIST, X, Y, Z, W),
+	                            al(VARIABLE_SET, X, Y, Z, W),
 	                            al(PRESENT_LINK,
 	                               al(INHERITANCE_LINK, X, Y),
 	                               al(INHERITANCE_LINK, Z, Y),


### PR DESCRIPTION
Improvements due to using `VariableSet` in the patterns and inference rules, although not as spectacular as I hoped, are very decent (according to my unit tests):

- Cut up to 45% search space during frequent pattern mining
- Cut up to 20% search space during surprisingness

No dataset has been manufactured to draw these numbers, I just used my existing unit tests datasets, so it's still not clear in practice how better it will perform. This highly depends on the number of variables involved during the search.

It's not as spectacular because it only eliminates redundancies due to search confluence (most redundancies are already eliminated by the rules themselves). But given that it's a search space cut, rather than a CPU optimization, it affects all downstream processes, and ultimately myself poring over the results, which is always welcome.