### PR TITLE
Add max conjuncts specialization

### DIFF
--- a/examples/miner/2-conjunct/2-conjunct.scm
+++ b/examples/miner/2-conjunct/2-conjunct.scm
@@ -56,14 +56,10 @@
 ;;     (Variable "$X-0")
 ;;     (Variable "$X-1"))))
 ;;
-;; TODO: the following bugs for no reason
-;; (cog-mine (cog-atomspace)
-;;           #:minsup 2
-;;           #:initpat (conjunct-pattern 2)
-;;           #:conjunction-expansion #f)
 (define results (cog-mine (list AB BC DE EF)
                           #:minsup 2
                           #:initpat (conjunct-pattern 2)
                           #:conjunction-expansion #f
                           #:max-variables 4
+                          #:maximum-spcial-conjuncts 2
                           #:surprisingness 'none))

--- a/examples/miner/mozi-ai/mozi-ai-utils.scm
+++ b/examples/miner/mozi-ai/mozi-ai-utils.scm
@@ -19,7 +19,7 @@
   (cog-subtype? 'EvaluationLink (cog-type x)))
 
 (define (eval-pred-name? name x)
-  (and (cog-subtype? 'EvaluationLink (cog-type x))
+  (and (eval? x)
        (equal? (cog-name (gar x)) name)))
 
 (define (forall? p l)
@@ -110,7 +110,7 @@
          (db-as (cog-atomspace))
          (db-lst (get-db-lst db-as))
 
-         ;; Filter in addimissible types from db-lst
+         ;; Filter in admissible types from db-lst
          (eval-has_pubmedID? (lambda (x) (eval-pred-name? "has_pubmedID" x)))
          (eval-has_definition? (lambda (x) (eval-pred-name? "has_definition" x)))
          (eval-has_name? (lambda (x) (eval-pred-name? "has_name" x)))

--- a/opencog/miner/rules/shallow-specialization.scm
+++ b/opencog/miner/rules/shallow-specialization.scm
@@ -37,16 +37,17 @@
 
 (load "miner-rule-utils.scm")
 
-;; Generate a shallow specialization rule. If unary is #t then it adds
-;; the constraint that the pattern must be unary. This is to avoid
-;; specializing conjunctions of abstract patterns that may result in
-;; circumventing the the conjunction expansion rule heuristic.
+;; Generate a shallow specialization rule.
+
+;; nary is the number of conjuncts the pattern must have to be
+;; allowed to be specialized (as it is an expensive operation).
 ;;
 ;; mv is the maximum number of variable allowed in the resulting
 ;; patterns.
-(define (gen-shallow-specialization-rule unary mv)
+(define (gen-shallow-specialization-rule nary mv)
   (let* (;; Variables
-         (pattern (Variable "$pattern"))
+         (pattern-vardecl (Variable "$vardecl"))
+         (cnjs (gen-variables "$cnj" nary))
          (db (Variable "$db"))
          (ms (Variable "$ms"))
          ;; Types
@@ -54,20 +55,23 @@
          (ConceptT (Type "ConceptNode"))
          (NumberT (Type "NumberNode"))
          ;; Vardecls
-         (pattern-decl (TypedVariable pattern LambdaT))
+         (pattern-vardecl-decl pattern-vardecl)
+         (cnjs-decls cnjs)
          (db-decl (TypedVariable db ConceptT))
          (ms-decl (TypedVariable ms NumberT))
          ;; Clauses
+         (pattern (Quote (Lambda (Unquote pattern-vardecl)
+                                 (Present (map Unquote cnjs)))))
          (minsup-pattern (minsup-eval pattern db ms)))
   (Bind
     (VariableSet
-      pattern-decl
+      pattern-vardecl-decl
+      cnjs-decls
       db-decl
       ms-decl)
     (And
       (Present minsup-pattern)
-      (absolutely-true-eval minsup-pattern)
-      (if unary (unary-conjunction-pattern-eval pattern) '()))
+      (absolutely-true-eval minsup-pattern))
     (ExecutionOutput
       (GroundedSchema (string-append "scm: shallow-specialization-mv-"
                                      (number->string mv)

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -110,6 +110,7 @@ private:
 	              bool conjunction_expansion=false,
 	              unsigned max_conjuncts=UINT_MAX,
 	              unsigned max_variables=UINT_MAX,
+	              unsigned max_spcial_conjuncts=1,
 	              unsigned max_cnjexp_variables=UINT_MAX,
 	              bool enforce_specialization=true,
 	              double complexity_penalty=0.0);
@@ -118,6 +119,7 @@ private:
 	              bool conjunction_expansion=false,
 	              unsigned max_conjuncts=UINT_MAX,
 	              unsigned max_variables=UINT_MAX,
+	              unsigned max_spcial_conjuncts=1,
 	              unsigned max_cnjexp_variables=UINT_MAX,
 	              bool enforce_specialization=true,
 	              double complexity_penalty=0.0);
@@ -218,6 +220,7 @@ Handle MinerUTest::ure_pm(const AtomSpace& db_as, int minsup,
                           bool conjunction_expansion,
                           unsigned max_conjuncts,
                           unsigned max_variables,
+                          unsigned max_spcial_conjuncts,
                           unsigned max_cnjexp_variables,
                           bool enforce_specialization,
                           double complexity_penalty)
@@ -226,6 +229,7 @@ Handle MinerUTest::ure_pm(const AtomSpace& db_as, int minsup,
 	                               maximum_iterations, initpat,
 	                               conjunction_expansion,
 	                               max_conjuncts, max_variables,
+	                               max_spcial_conjuncts,
 	                               max_cnjexp_variables,
 	                               enforce_specialization, complexity_penalty);
 }
@@ -235,6 +239,7 @@ Handle MinerUTest::ure_pm(const HandleSeq& db, int minsup,
                           bool conjunction_expansion,
                           unsigned max_conjuncts,
                           unsigned max_variables,
+                          unsigned max_spcial_conjuncts,
                           unsigned max_cnjexp_variables,
                           bool enforce_specialization,
                           double complexity_penalty)
@@ -243,6 +248,7 @@ Handle MinerUTest::ure_pm(const HandleSeq& db, int minsup,
 	                               maximum_iterations, initpat,
 	                               conjunction_expansion,
 	                               max_conjuncts, max_variables,
+	                               max_spcial_conjuncts,
 	                               max_cnjexp_variables,
 	                               enforce_specialization, complexity_penalty);
 }
@@ -974,7 +980,15 @@ void MinerUTest::test_AB_redundant_cnj()
 	// Run URE pattern miner without enforcing specialization (which is
 	// necessary to mine transitivity).
 	int ms = 1;
-	Handle results = ure_pm(db, ms, 50, top, true, 3, 2, 2, false);
+	int mi = 50;
+	bool cnj_exp = false;
+	unsigned max_cnjs = 3;
+	unsigned max_vars = 2;
+	unsigned max_spcial_cnjs = 1;
+	unsigned max_cnjexp_vars = 2;
+	bool enforce_spcial = false;
+	Handle results = ure_pm(db, ms, mi, top, cnj_exp, max_cnjs, max_vars,
+	                        max_spcial_cnjs, max_cnjexp_vars, enforce_spcial);
 	HandleSeq clauses = {al(INHERITANCE_LINK, A, Y),
 	                     al(INHERITANCE_LINK, Y, B),
 	                     al(INHERITANCE_LINK, X, Y)};
@@ -1243,7 +1257,15 @@ void MinerUTest::test_transitivity()
 	// Run URE pattern miner without enforcing specialization (which is
 	// necessary to mine transitivity).
 	int ms = 1;
-	Handle results = ure_pm(db, ms, 50, top, true, 2, 3, 3, false);
+	unsigned max_conjuncts = 2;
+	unsigned max_variables = 3;
+	unsigned max_spcial_conjuncts = 1;
+	unsigned max_cnjexp_variables = 3;
+	bool enforce_specialization = false;
+	Handle results = ure_pm(db, ms, 50, top, true,
+	                        max_conjuncts, max_variables,
+	                        max_spcial_conjuncts, max_cnjexp_variables,
+	                        enforce_specialization);
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Y, Z)};
 	Handle expected = mk_minsup_eval(ms,
@@ -1276,11 +1298,13 @@ void MinerUTest::test_long_transitivity()
 	bool conjunction_expansion = true;
 	unsigned max_conjuncts = 3;
 	unsigned max_variables = 4;
+	unsigned max_spcial_conjuncts = 1;
 	unsigned max_cnjexp_variables = 4;
 	bool enforce_specialization = false;
 	double complexity_penalty = 1.0;
 	Handle results = ure_pm(db, ms, max_iteration, top, conjunction_expansion,
-	                        max_conjuncts, max_variables, max_cnjexp_variables,
+	                        max_conjuncts, max_variables,
+	                        max_spcial_conjuncts, max_cnjexp_variables,
 	                        enforce_specialization, complexity_penalty);
 	HandleSeq clauses = {al(INHERITANCE_LINK, X, Y),
 	                     al(INHERITANCE_LINK, Y, Z),
@@ -1417,7 +1441,14 @@ void MinerUTest::test_2conjuncts_2()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(db, 2, 2, initpat),
+	int ms = 2;
+	int mi = 2;
+	bool cnj_exp = false;
+	unsigned max_cnjs = 2;
+	unsigned max_vars = 3;
+	unsigned max_spcial_cnjs = 2;
+	Handle ure_results = ure_pm(db, ms, mi, initpat, cnj_exp,
+	                            max_cnjs, max_vars, max_spcial_cnjs),
 		ure_expected = mk_minsup_eval(2,
 		                              MinerUtils::mk_pattern(VarXYZ,
 		                                                     {InhXY, InhYZ}));
@@ -1453,7 +1484,14 @@ void MinerUTest::test_2conjuncts_3()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(db, 2, 50, mk_nconjunct(2)),
+	int ms = 2;
+	int mi = 50;
+	bool cnj_exp = false;
+	unsigned max_cnjs = 2;
+	unsigned max_vars = 4;
+	unsigned max_spcial_cnjs = 2;
+	Handle ure_results = ure_pm(db, ms, mi, mk_nconjunct(2), cnj_exp,
+	                            max_cnjs, max_vars, max_spcial_cnjs),
 		ure_expected = mk_minsup_eval(2,
 		                              MinerUtils::mk_pattern(VarXYZ,
 		                                                     {InhXY, InhYZ}));
@@ -1490,7 +1528,14 @@ void MinerUTest::test_2conjuncts_4()
 	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(db, 4, 100, mk_nconjunct(2)),
+	int ms = 4;
+	int mi = 100;
+	bool cnj_exp = false;
+	unsigned max_cnjs = 2;
+	unsigned max_vars = 4;
+	unsigned max_spcial_cnjs = 2;
+	Handle ure_results = ure_pm(db, ms, mi, mk_nconjunct(2), cnj_exp,
+	                            max_cnjs, max_vars, max_spcial_cnjs),
 		ure_expected = mk_minsup_eval(4,
 		                              MinerUtils::mk_pattern(VarXYZ,
 		                                                     {InhXY, InhYZ}));
@@ -1661,7 +1706,14 @@ void MinerUTest::test_InferenceControl()
 	TS_ASSERT(content_is_in(expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(_tmp_as, 2, 100, initpat),
+	int ms = 2;
+	int mi = 100;
+	bool cnj_exp = false;
+	unsigned max_cnjs = 3;
+	unsigned max_vars = 5;
+	unsigned max_spcial_cnjs = 3;
+	Handle ure_results = ure_pm(_tmp_as, ms, mi, initpat, cnj_exp,
+	                            max_cnjs, max_vars, max_spcial_cnjs),
 		ure_expected = mk_minsup_eval(2, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
@@ -1714,7 +1766,14 @@ void MinerUTest::test_SodaDrinker()
 	TS_ASSERT(content_is_in(expected, cpp_results));
 
 	// Run URE pattern miner
-	Handle ure_results = ure_pm(_tmp_as, 5, 500, initpat),
+	int ms = 5;
+	int mi = 200;
+	bool cnj_exp = false;
+	unsigned max_cnjs = 3;
+	unsigned max_vars = 4;
+	unsigned max_spcial_cnjs = 3;
+	Handle ure_results = ure_pm(_tmp_as, ms, mi, initpat, cnj_exp,
+	                            max_cnjs, max_vars, max_spcial_cnjs),
 		ure_expected = mk_minsup_eval(5, expected);
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
@@ -1745,6 +1804,7 @@ void MinerUTest::test_SodaDrinker_incremental()
 	bool conjunction_expansion = true;
 	unsigned max_conjuncts = 3;
 	unsigned max_variables = 2;
+	unsigned max_spcial_conjuncts = 1;
 	unsigned max_cnjexp_variables = 1;
 	bool enforce_specialization = true;
 	double complexity_penalty = 1;
@@ -1753,9 +1813,8 @@ void MinerUTest::test_SodaDrinker_incremental()
 	Handle ure_results = ure_pm(_tmp_as, minsup, max_iteration,
 	                            initpat,
 	                            conjunction_expansion,
-	                            max_conjuncts,
-	                            max_variables,
-	                            max_cnjexp_variables,
+	                            max_conjuncts, max_variables,
+	                            max_spcial_conjuncts, max_cnjexp_variables,
 	                            enforce_specialization,
 	                            complexity_penalty);
 
@@ -1903,15 +1962,15 @@ void MinerUTest::test_vqa()
 	int max_iteration = 5;
 	unsigned max_conjuncts = 2;
 	unsigned max_variables = 3;
+	unsigned max_spcial_conjuncts = 1;
 	unsigned max_cnjexp_variables = 3;
 	bool enforce_specialization = false;
 	double complexity_penalty = 1;
 	Handle results = ure_pm(_tmp_as, minsup, max_iteration,
 	                        initpat,
 	                        conjunction_expansion,
-	                        max_conjuncts,
-	                        max_variables,
-	                        max_cnjexp_variables,
+	                        max_conjuncts, max_variables,
+	                        max_spcial_conjuncts, max_cnjexp_variables,
 	                        enforce_specialization,
 	                        complexity_penalty),
 		expect = mk_minsup_eval(minsup, expect_pat);

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -29,6 +29,7 @@
 #include <opencog/util/random.h>
 #include <opencog/util/algorithm.h>
 #include <opencog/guile/SchemeSmob.h>
+#include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/ure/forwardchainer/ForwardChainer.h>
 #include <opencog/ure/backwardchainer/BackwardChainer.h>
 
@@ -119,7 +120,10 @@ Handle MinerUTestUtils::add_abs_true_eval(AtomSpace& as, const Handle& h)
 
 Handle MinerUTestUtils::add_nconjunct(AtomSpace& as, unsigned n)
 {
-	return al(LAMBDA_LINK, al(AND_LINK, add_variables(as, "$X-", n)));
+	HandleSeq vars = add_variables(as, "$X-", n);
+	return al(LAMBDA_LINK,
+	          al(VARIABLE_SET, vars),
+	          al(PRESENT_LINK, vars));
 }
 
 Handle MinerUTestUtils::add_variable(AtomSpace& as,
@@ -149,6 +153,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                bool conjunction_expansion,
                                unsigned max_conjuncts,
                                unsigned max_variables,
+                               unsigned max_spcial_conjuncts,
                                unsigned max_cnjexp_variables,
                                bool enforce_specialization,
                                double complexity_penalty)
@@ -158,7 +163,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 	                          opencog::ATOM, true);
 	return ure_pm(as, scm, pm_rb, db, minsup, maximum_iterations, initpat,
 	              conjunction_expansion, max_conjuncts, max_variables,
-	              max_cnjexp_variables,
+	              max_spcial_conjuncts, max_cnjexp_variables,
 	              enforce_specialization, complexity_penalty);
 }
 
@@ -172,6 +177,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                bool conjunction_expansion,
                                unsigned max_conjuncts,
                                unsigned max_variables,
+                               unsigned max_spcial_conjuncts,
                                unsigned max_cnjexp_variables,
                                bool enforce_specialization,
                                double complexity_penalty)
@@ -180,9 +186,12 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 	for (const Handle& dt : db)
 		al(MEMBER_LINK, dt, add_db_cpt(as));
 
-	// If init is not defined then use top
+	// If initpat is not defined then use top
 	if (not initpat)
 		initpat = add_top(as);
+
+	// Add a variable default declaration if needed
+	initpat = add_default_vardecl(initpat);
 
 	// Add the axiom that initpat has enough support, and use it as
 	// source for the forward chainer
@@ -193,8 +202,12 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
 		return al(SET_LINK);
 
 	// Add incremental conjunction expansion if necessary
-	configure_optional_rules(scm, conjunction_expansion, max_conjuncts,
-	                         max_variables, max_cnjexp_variables,
+	configure_optional_rules(scm,
+	                         conjunction_expansion,
+	                         max_conjuncts,
+	                         max_variables,
+	                         max_spcial_conjuncts,
+	                         max_cnjexp_variables,
 	                         enforce_specialization);
 
 	// Otherwise prepare the source
@@ -300,6 +313,7 @@ void MinerUTestUtils::configure_optional_rules(SchemeEval& scm,
                                                bool conjunction_expansion,
                                                unsigned max_conjuncts,
                                                unsigned max_variables,
+                                               unsigned max_spcial_conjuncts,
                                                unsigned max_cnjexp_variables,
                                                bool enforce_specialization)
 {
@@ -310,6 +324,8 @@ void MinerUTestUtils::configure_optional_rules(SchemeEval& scm,
 	call += std::to_string(max_conjuncts);
 	call += " #:maximum-variables ";
 	call += std::to_string(max_variables);
+	call += " #:maximum-spcial-conjuncts ";
+	call += std::to_string(max_spcial_conjuncts);
 	call += " #:maximum-cnjexp-variables ";
 	call += std::to_string(max_cnjexp_variables);
 	call += " #:enforce-specialization ";
@@ -378,4 +394,13 @@ HandleSeq MinerUTestUtils::populate_links(AtomSpace& as,
 		if (biased_randbool(p))
 			links.insert(as.add_link(type, outgoing));
 	return HandleSeq(links.begin(), links.end());
+}
+
+Handle MinerUTestUtils::add_default_vardecl(const Handle& pattern)
+{
+	if (1 < pattern->get_arity())
+		return pattern;
+	Handle vardecl = ScopeLinkCast(pattern)->get_variables().get_vardecl();
+	Handle body = pattern->getOutgoingAtom(0);
+	return HandleCast(createLambdaLink(vardecl, body));
 }

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -137,7 +137,7 @@ public:
 	 *
 	 * (Lambda
 	 *   (VariableList X1 ... Xn)
-	 *   (And X1 ... Xn))
+	 *   (Present X1 ... Xn))
 	 *
 	 * to as.
 	 */
@@ -181,6 +181,7 @@ public:
 	                     bool conjunction_expansion=false,
 	                     unsigned max_conjuncts=UINT_MAX,
 	                     unsigned max_variables=UINT_MAX,
+	                     unsigned max_spcial_conjuncts=1,
 	                     unsigned max_cnjexp_variables=UINT_MAX,
 	                     bool enforce_specialization=true,
 	                     double complexity_penalty=0.0);
@@ -193,6 +194,7 @@ public:
 	                     bool conjunction_expansion=false,
 	                     unsigned max_conjuncts=UINT_MAX,
 	                     unsigned max_variables=UINT_MAX,
+	                     unsigned max_spcial_conjuncts=1,
 	                     unsigned max_cnjexp_variables=UINT_MAX,
 	                     bool enforce_specialization=true,
 	                     double complexity_penalty=0.0);
@@ -281,6 +283,7 @@ public:
 	                                     bool conjunction_expansion,
 	                                     unsigned max_conjuncts=UINT_MAX,
 	                                     unsigned max_variables=UINT_MAX,
+	                                     unsigned max_spcial_conjuncts=1,
 	                                     unsigned max_cnjexp_variables=UINT_MAX,
 	                                     bool enforce_specialization=false);
 	static void configure_surprisingness(SchemeEval& scm,
@@ -319,6 +322,11 @@ public:
 	                                Type type,
 	                                unsigned arity,
 	                                double p);
+
+	/**
+	 * Add a default variable declaration if pattern is missing one.
+	 */
+	static Handle add_default_vardecl(const Handle& pattern);
 };
 
 } // ~namespace opencog


### PR DESCRIPTION
Add option to set the number of conjuncts of patterns where the shallow specialization rule can apply to. Shallow specialization is expensive on patterns with more than one conjunct, thus was disabled by default for large conjunctions. However in many cases it is tractable and useful, thus this option.