### PR TITLE
Avoid copying of data

### DIFF
--- a/opencog/miner/MinerSCM.cc
+++ b/opencog/miner/MinerSCM.cc
@@ -211,7 +211,7 @@ Handle MinerSCM::do_shallow_abstract(Handle pattern,
 			sa_lists.insert(sa_list.size() == 1 ? sa_list[0]
 			                // Only Wrap in a list if arity is greater
 			                // than one
-			                : as->add_link(LIST_LINK, sa_list));
+			                : as->add_link(LIST_LINK, std::move(sa_list)));
 		}
 		vari++;
 	}

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -469,7 +469,7 @@ Handle MinerUtils::restricted_satisfying_set(const Handle& pattern,
 
 	// Avoid pattern matcher warning
 	if (totally_abstract(pattern) and n_conjuncts(pattern) == 1)
-		return tmp_db_as.add_link(SET_LINK, tmp_db);
+		return tmp_db_as.add_link(SET_LINK, std::move(tmp_db));
 
 	// Define pattern to run
 	AtomSpace tmp_query_as(&tmp_db_as);

--- a/opencog/miner/Surprisingness.cc
+++ b/opencog/miner/Surprisingness.cc
@@ -123,7 +123,7 @@ Handle Surprisingness::add_pattern(const HandleSeq& block, AtomSpace& as)
 {
 	return as.add_link(LAMBDA_LINK,
 	                   block.size() == 1 ? block.front()
-	                   : as.add_link(AND_LINK, block));
+	                   : as.add_link(AND_LINK, std::move(HandleSeq(block))));
 }
 
 HandleSeq Surprisingness::add_subpatterns(const HandleSeqSeq& partition,

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -121,9 +121,10 @@ Handle MinerUTestUtils::add_abs_true_eval(AtomSpace& as, const Handle& h)
 Handle MinerUTestUtils::add_nconjunct(AtomSpace& as, unsigned n)
 {
 	HandleSeq vars = add_variables(as, "$X-", n);
+	HandleSeq varz = vars;
 	return al(LAMBDA_LINK,
-	          al(VARIABLE_SET, std::move(HandleSeq(vars))),
-	          al(PRESENT_LINK, std::move(vars)));
+	          al(VARIABLE_SET, std::move(vars)),
+	          al(PRESENT_LINK, std::move(varz)));
 }
 
 Handle MinerUTestUtils::add_variable(AtomSpace& as,

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -48,9 +48,9 @@ Handle MinerUTestUtils::add_minsup_prd(AtomSpace& as)
 	return an(PREDICATE_NODE, "minsup");
 }
 
-Handle MinerUTestUtils::add_surp_prd(AtomSpace& as, const std::string& mode)
+Handle MinerUTestUtils::add_surp_prd(AtomSpace& as, std::string mode)
 {
-	return an(PREDICATE_NODE, mode);
+	return an(PREDICATE_NODE, std::move(mode));
 }
 
 Handle MinerUTestUtils::add_top(AtomSpace& as)
@@ -83,7 +83,7 @@ Handle MinerUTestUtils::add_minsup_evals(AtomSpace& as,
 	HandleSeq minsup_evals;
 	for (const Handle& pat : patterns)
 		minsup_evals.push_back(add_minsup_eval(as, pat, minsup, tv));
-	return al(SET_LINK, minsup_evals);
+	return al(SET_LINK, std::move(minsup_evals));
 }
 
 Handle MinerUTestUtils::add_surp_eval(AtomSpace& as,
@@ -122,8 +122,8 @@ Handle MinerUTestUtils::add_nconjunct(AtomSpace& as, unsigned n)
 {
 	HandleSeq vars = add_variables(as, "$X-", n);
 	return al(LAMBDA_LINK,
-	          al(VARIABLE_SET, vars),
-	          al(PRESENT_LINK, vars));
+	          al(VARIABLE_SET, std::move(HandleSeq(vars))),
+	          al(PRESENT_LINK, std::move(vars)));
 }
 
 Handle MinerUTestUtils::add_variable(AtomSpace& as,
@@ -392,7 +392,7 @@ HandleSeq MinerUTestUtils::populate_links(AtomSpace& as,
 	HandleSet links;
 	for (const HandleSeq& outgoing : cartesian_product(hs, arity))
 		if (biased_randbool(p))
-			links.insert(as.add_link(type, outgoing));
+			links.insert(as.add_link(type, std::move(HandleSeq(outgoing))));
 	return HandleSeq(links.begin(), links.end());
 }
 

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -58,7 +58,7 @@ public:
 	 *
 	 * to as.
 	 */
-	static Handle add_surp_prd(AtomSpace& as, const std::string& mode);
+	static Handle add_surp_prd(AtomSpace& as, std::string mode);
 
 	/**
 	 * Add


### PR DESCRIPTION
Use std::move to create rvalues. Needed for pull req opencog/atomspace#2512