### PR TITLE
Add user option to better control computational resources

### DIFF
--- a/examples/miner/mozi-ai/mozi-ai-utils.scm
+++ b/examples/miner/mozi-ai/mozi-ai-utils.scm
@@ -230,7 +230,7 @@
     base-minsup-ptns-lst))
 
 ;; TODO: move this to miner-utils.scm, maybe
-(define (cog-surp surprisingness max-conjuncts db-cpt)
+(define (cog-surp surprisingness max-conjuncts db-cpt db-ratio)
   (let* (
          ;; Configure surprisingness backward chainer
          (surp-rbs (random-surprisingness-rbs-cpt))
@@ -238,7 +238,8 @@
          (vardecl (surp-vardecl))
          (cfg-s (configure-surprisingness surp-rbs
                                           surprisingness
-                                          max-conjuncts))
+                                          max-conjuncts
+					  db-ratio))
 
          ;; Run surprisingness in a backward way
          (results (cog-bc surp-rbs target #:vardecl vardecl)))

--- a/examples/miner/mozi-ai/surp-mozi-ai.scm
+++ b/examples/miner/mozi-ai/surp-mozi-ai.scm
@@ -11,6 +11,7 @@
 (define ptns-filename "test.scm")
 (define surp 'nisurp)
 (define max-cnjs 3)
+(define db-ratio 1)
 
 ;; Load modules & utils
 (use-modules (srfi srfi-1))
@@ -67,7 +68,7 @@
                                               "surp = ~a\n"
                                               "max-cnjs = ~a")
                                surp max-cnjs))
-         (results (cog-outgoing-set (cog-surp surp max-cnjs db-cpt)))
+         (results (cog-outgoing-set (cog-surp surp max-cnjs db-cpt db-ratio)))
          (msg (cog-logger-info "Results of surprisingness over ~a:\nsize = ~a\n~a"
                                kb-filename (length results) results)))
     results))

--- a/opencog/miner/MinerSCM.cc
+++ b/opencog/miner/MinerSCM.cc
@@ -110,15 +110,15 @@ protected:
 	 * do_isurp: I-Surprisingness
 	 * do_nisurp: normalized I-Surprisingness
 	 */
-	double do_isurp_old(Handle pattern, Handle db);
-	double do_nisurp_old(Handle pattern, Handle db);
-	double do_isurp(Handle pattern, Handle db);
-	double do_nisurp(Handle pattern, Handle db);
+	double do_isurp_old(Handle pattern, Handle db, Handle /*db_ratio unused*/);
+	double do_nisurp_old(Handle pattern, Handle db, Handle /*db_ratio unused*/);
+	double do_isurp(Handle pattern, Handle db, Handle db_ratio);
+	double do_nisurp(Handle pattern, Handle db, Handle db_ratio);
 
 	/**
 	 * Calculate the empirical truth value of pattern
 	 */
-	TruthValuePtr do_emp_tv(Handle pattern, Handle db);
+	TruthValuePtr do_emp_tv(Handle pattern, Handle db, Handle db_ratio);
 
 	/**
 	 * Calculate the joint independent truth value estimate of pattern
@@ -268,7 +268,7 @@ Handle MinerSCM::do_expand_conjunction(Handle cnjtion, Handle pattern,
 	return as->add_link(SET_LINK, HandleSeq(results.begin(), results.end()));
 }
 
-double MinerSCM::do_isurp_old(Handle pattern, Handle db)
+double MinerSCM::do_isurp_old(Handle pattern, Handle db, Handle /*db_ratio*/)
 {
 	// Fetch data trees
 	HandleSeq db_seq = MinerUtils::get_db(db);
@@ -276,38 +276,41 @@ double MinerSCM::do_isurp_old(Handle pattern, Handle db)
 	return Surprisingness::isurp_old(pattern, db_seq, false);
 }
 
-double MinerSCM::do_nisurp_old(Handle pattern, Handle db)
+double MinerSCM::do_nisurp_old(Handle pattern, Handle db, Handle /*db_ratio*/)
 {
-	// Fetch data trees
+	// Fetch arguments
 	HandleSeq db_seq = MinerUtils::get_db(db);
 
 	return Surprisingness::isurp_old(pattern, db_seq, true);
 }
 
-double MinerSCM::do_isurp(Handle pattern, Handle db)
+double MinerSCM::do_isurp(Handle pattern, Handle db, Handle db_ratio)
 {
-	// Fetch data trees
+	// Fetch arguments
 	HandleSeq db_seq = MinerUtils::get_db(db);
+	double db_rat = MinerUtils::get_double(db_ratio);
 
-	return Surprisingness::isurp(pattern, db_seq, false);
+	return Surprisingness::isurp(pattern, db_seq, false, db_rat);
 }
 
-double MinerSCM::do_nisurp(Handle pattern, Handle db)
+double MinerSCM::do_nisurp(Handle pattern, Handle db, Handle db_ratio)
 {
-	// Fetch data trees
+	// Fetch arguments
 	HandleSeq db_seq = MinerUtils::get_db(db);
+	double db_rat = MinerUtils::get_double(db_ratio);
 
-	return Surprisingness::isurp(pattern, db_seq, true);
+	return Surprisingness::isurp(pattern, db_seq, true, db_rat);
 }
 
-TruthValuePtr MinerSCM::do_emp_tv(Handle pattern, Handle db)
+TruthValuePtr MinerSCM::do_emp_tv(Handle pattern, Handle db, Handle db_ratio)
 {
-	// Fetch data trees
+	// Fetch arguments
 	HandleSeq db_seq = MinerUtils::get_db(db);
+	double db_rat = MinerUtils::get_double(db_ratio);
 
 	// Calculate its estimate first to optimize empirical calculation
 	TruthValuePtr jte = Surprisingness::ji_tv_est_mem(pattern, db_seq);
-	return Surprisingness::emp_tv_pbs_mem(pattern, db_seq, jte->get_mean());
+	return Surprisingness::emp_tv_pbs_mem(pattern, db_seq, jte->get_mean(), db_rat);
 }
 
 TruthValuePtr MinerSCM::do_ji_tv_est(Handle pattern, Handle db)

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -309,8 +309,12 @@ HandleSeq MinerUtils::get_db(const Handle& db_cpt)
 
 unsigned MinerUtils::get_uint(const Handle& h)
 {
-	NumberNodePtr nn = NumberNodeCast(h);
-	return (unsigned)std::round(nn->get_value());
+	return (unsigned)std::round(get_double(h));
+}
+
+double MinerUtils::get_double(const Handle& h)
+{
+	return NumberNodeCast(h)->get_value();
 }
 
 unsigned MinerUtils::support(const Handle& pattern,

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -184,6 +184,11 @@ public:
 	static unsigned get_uint(const Handle& h);
 
 	/**
+	 * Return the double held by a number node.
+	 */
+	static double get_double(const Handle& h);
+
+	/**
 	 * Given a pattern and a db, calculate the pattern frequency up to
 	 * ms (to avoid unnecessary calculations).
 	 */

--- a/opencog/miner/Surprisingness.cc
+++ b/opencog/miner/Surprisingness.cc
@@ -309,17 +309,17 @@ double Surprisingness::emp_prob_pbs(const Handle& pattern,
 	// If the support estimate is above the db size then we
 	// subsample
 	if (db_size < support_estimate) {
-		LAZY_LOG_DEBUG << "[Miner] Pattern" << std::endl << oc_to_string(pattern)
-		               << std::endl << "has support estimate " << support_estimate
-		               << " > " << db_size << " (its rescaled db size)";
+		LAZY_LOG_FINE << "[Miner] Pattern" << std::endl << oc_to_string(pattern)
+		              << std::endl << "has support estimate " << support_estimate
+		              << " > " << db_size << " (its rescaled db size)";
 		// Calculate the empirical probability of pattern
 		unsigned subsize = subsmp_size(pattern, db_size, support_estimate);
 		unsigned n_resample = 10;  // TODO: move this hardwired contant
 		                             // to a user parameter
-		LAZY_LOG_DEBUG << "[Miner] Downsample the db to " << subsize
-		               << " to avoid excessively large support,"
-		               << " boostrapping" << " (x" << n_resample << ")"
-		               << " to reduce inaccuracies.";
+		LAZY_LOG_FINE << "[Miner] Downsample the db to " << subsize
+		              << " to avoid excessively large support,"
+		              << " boostrapping" << " (x" << n_resample << ")"
+		              << " to reduce inaccuracies.";
 		double emp_prob = emp_prob_bs(pattern, db, n_resample, subsize);
 		if (emp_prob == 0) {
 			LAZY_LOG_WARN << "[Miner] The empirical probability of pattern" << std::endl
@@ -329,10 +329,10 @@ double Surprisingness::emp_prob_pbs(const Handle& pattern,
 		}
 		return emp_prob;
 	} else {
-		LAZY_LOG_DEBUG << "[Miner] Pattern " << std::endl << oc_to_string(pattern)
-		               << std::endl << "has support estimate " << support_estimate
-		               << " <= " << db_size << " (its rescaled db size)"
-		               << ". No bootstrapping is taking place.";
+		LAZY_LOG_FINE << "[Miner] Pattern " << std::endl << oc_to_string(pattern)
+		              << std::endl << "has support estimate " << support_estimate
+		              << " <= " << db_size << " (its rescaled db size)"
+		              << ". No subsampling is taking place.";
 		return emp_prob(pattern, db);
 	}
 }

--- a/opencog/miner/Surprisingness.h
+++ b/opencog/miner/Surprisingness.h
@@ -334,7 +334,8 @@ public:
 	 */
 	static double isurp(const Handle& pattern,
 	                    const HandleSeq& db,
-	                    bool normalize=true);
+	                    bool normalize=true,
+	                    double db_ratio=1.0);
 
 	/**
 	 * Return the distance between a value and an interval
@@ -442,7 +443,7 @@ public:
 	                              double prob);
 
 	/**
-	 * Calculate the empiric probability of a pattern according to a
+	 * Calculate the empirical probability of a pattern according to a
 	 * database db.
 	 */
 	static double emp_prob(const Handle& pattern, const HandleSeq& db);
@@ -485,22 +486,26 @@ public:
 	 * pbs stands for possibly boostrapping.
 	 */
 	static double emp_prob_pbs(const Handle& pattern,
-	                           const HandleSeq& db);
+	                           const HandleSeq& db,
+	                           double db_ratio);
 	static double emp_prob_pbs(const Handle& pattern,
 	                           const HandleSeq& db,
-	                           double prob_estimate);
+	                           double prob_estimate,
+	                           double db_ratio);
 
 	/**
 	 * Like emp_prob_pbs with memoization.
 	 */
 	static double emp_prob_pbs_mem(const Handle& pattern,
-	                               const HandleSeq& db);
+	                               const HandleSeq& db,
+	                               double db_ratio);
 	static double emp_prob_pbs_mem(const Handle& pattern,
 	                               const HandleSeq& db,
-	                               double prob_estimate);
+	                               double prob_estimate,
+	                               double db_ratio);
 
 	/**
-	 * Calculate the empiric truth value of a pattern according to a
+	 * Calculate the empirical truth value of a pattern according to a
 	 * database db.
 	 */
 	static TruthValuePtr emp_tv(const Handle& pattern, const HandleSeq& db);
@@ -540,14 +545,16 @@ public:
 	 */
 	static TruthValuePtr emp_tv_pbs(const Handle& pattern,
 	                                const HandleSeq& db,
-	                                double prob_estimate);
+	                                double prob_estimate,
+	                                double db_ratio);
 
 	/**
 	 * Like emp_tv_pbs with memoization.
 	 */
 	static TruthValuePtr emp_tv_pbs_mem(const Handle& pattern,
 	                                    const HandleSeq& db,
-	                                    double prob_estimate);
+	                                    double prob_estimate,
+	                                    double db_ratio);
 
 	/**
 	 * Randomly subsample db so that the resulting db has size
@@ -591,15 +598,17 @@ public:
 	 * alpha = support_estimate / ts^nc
 	 */
 	static unsigned subsmp_size(const Handle& pattern,
-	                            const HandleSeq& db,
-	                            double support_estimate);
+	                            double db_size,
+	                            double support_estimate,
+	                            unsigned min_subsize=10U);
 
 	/**
 	 * Calculate min and max probability estimates of a pattern by
 	 * applying ji_prob_est over all its possible partitions.
 	 */
 	static std::pair<double, double> ji_prob_est_interval(const Handle& pattern,
-	                                                      const HandleSeq& db);
+	                                                      const HandleSeq& db,
+	                                                      double db_ratio);
 
 	/**
 	 * Calculate probability estimate of a pattern given a partition,
@@ -609,7 +618,8 @@ public:
 	 */
 	static double ji_prob_est(const HandleSeqSeq& partition,
 	                          const Handle& pattern,
-	                          const HandleSeq& db);
+	                          const HandleSeq& db,
+	                          double db_ratio);
 
 	/**
 	 * Calculate truth value estimate of a pattern given a partition,

--- a/opencog/miner/rules/emp.scm
+++ b/opencog/miner/rules/emp.scm
@@ -21,21 +21,45 @@
 
 (load "miner-rule-utils.scm")
 
-(define (gen-emp-rule)
-  (let* (;; Variables
-         (pattern (Variable "$pattern"))
-         (db (Variable "$db"))
-         (ms (Variable "$ms"))
+;; Generate the empirical truth value of a pattern, given the
+;; following argument
+;;
+;; - db-ratio: parameter to control how much downsampling is used to
+;;             estimate the empirical probability. The surprisingness
+;;             code may automatically downsample the dataset to a
+;;             certain amount to reduce the computational burden of
+;;             calculating the empirical probability, while preserving
+;;             accuracy. However sometimes the user may want to tune
+;;             that, either by increasing downsampling so save
+;;             computational resources, or decreasing downsampling to
+;;             improve accuracy. This parameter indicates the
+;;             proportion of the dataset to consider when comparing
+;;             the estimate of the pattern count to the dataset
+;;             size. The default is 1.0, the rational is that if the
+;;             computer has enough RAM to hold a dataset of size s,
+;;             then it likely has enough RAM to hold s instances of a
+;;             pattern applied over that dataset, so if the estimate
+;;             count of instances is below s no subsampling is taking
+;;             place, otherwise subsampling is taking place as to not
+;;             exceed s. One can modify that threshold by considering
+;;             db-ratio * s instead of s (the default).
+(define (gen-emp-rule db-ratio)
+  (let* (;; Parameter
+	 [db-ratio-n (Number db-ratio)]
+	 ;; Variables
+         [pattern (Variable "$pattern")]
+         [db (Variable "$db")]
+         [ms (Variable "$ms")]
          ;; Types
-         (LambdaT (Type "LambdaLink"))
-         (ConceptT (Type "ConceptNode"))
-         (NumberT (Type "NumberNode"))
+         [LambdaT (Type "LambdaLink")]
+         [ConceptT (Type "ConceptNode")]
+         [NumberT (Type "NumberNode")]
          ;; Vardecls
-         (pattern-decl (TypedVariable pattern LambdaT))
-         (db-decl (TypedVariable db ConceptT))
-         (ms-decl (TypedVariable ms NumberT))
+         [pattern-decl (TypedVariable pattern LambdaT)]
+         [db-decl (TypedVariable db ConceptT)]
+         [ms-decl (TypedVariable ms NumberT)]
          ;; Clauses
-         (minsup-pattern (minsup-eval pattern db ms)))
+         [minsup-pattern (minsup-eval pattern db ms)])
   (Bind
     (VariableSet
       pattern-decl
@@ -47,16 +71,21 @@
     (ExecutionOutput
       (GroundedSchema "scm: emp-formula")
       (List
+        ;; Conclusion
         (emp-eval pattern db)
-        minsup-pattern)))))
+	;; Premise
+        minsup-pattern
+	;; Parameter
+	db-ratio-n)))))
 
 (define (emp-formula conclusion . premises)
   ;; (cog-logger-debug "emp-formula conclusion = ~a, premises = ~a"
   ;;                   conclusion premises)
-  (if (= (length premises) 1)
-      (let* ((minsup-pattern (car premises))
-             (pattern (get-pattern minsup-pattern))
-             (db (get-db minsup-pattern))
-             (emp-tv (cog-emp-tv pattern db)))
+  (if (= (length premises) 2)
+      (let* ([minsup-pattern (car premises)]
+	     [db-ratio (cadr premises)]
+             [pattern (get-pattern minsup-pattern)]
+             [db (get-db minsup-pattern)]
+             [emp-tv (cog-emp-tv pattern db db-ratio)])
         ;; (cog-logger-debug "emp-tv = ~a" emp-tv)
         (cog-set-tv! conclusion emp-tv))))

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -339,12 +339,14 @@ void MinerUTestUtils::configure_optional_rules(SchemeEval& scm,
 void MinerUTestUtils::configure_surprisingness(SchemeEval& scm,
                                                const Handle& surp_rb,
                                                const std::string& mode,
-                                               unsigned max_conjuncts)
+                                               unsigned max_conjuncts,
+                                               double db_ratio)
 {
 	std::string call = "(configure-surprisingness (Concept \""
 		+ surp_rb->get_name() + "\") ";
 	call += std::string("'") + mode + " ";
-	call += std::to_string(max_conjuncts);
+	call += std::to_string(max_conjuncts) + " ";
+	call += std::to_string(db_ratio);
 	call += ")";
 	std::string rs = scm.eval(call);
 	logger().debug() << "MinerUTest::configure_surprisingness() rs = " << rs;
@@ -354,9 +356,10 @@ HandleSeq MinerUTestUtils::ure_surp(AtomSpace& as,
                                     SchemeEval& scm,
                                     const Handle& surp_rb,
                                     const std::string& mode,
-                                    unsigned max_conjuncts)
+                                    unsigned max_conjuncts,
+                                    double db_ratio)
 {
-	configure_surprisingness(scm, surp_rb, mode, max_conjuncts);
+	configure_surprisingness(scm, surp_rb, mode, max_conjuncts, db_ratio);
 	Handle X = an(VARIABLE_NODE, "$X"),
 		target = add_surp_eval(as, mode, X),
 		vardecl = al(TYPED_VARIABLE_LINK, X, an(TYPE_NODE, "LambdaLink"));

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -289,7 +289,8 @@ public:
 	static void configure_surprisingness(SchemeEval& scm,
 	                                     const Handle& surp_rb,
 	                                     const std::string& mode,
-	                                     unsigned max_conjuncts);
+	                                     unsigned max_conjuncts,
+	                                     double db_ratio);
 
 	/**
 	 * Run I-Surprisingness reasoning on the current atomspace and
@@ -299,7 +300,8 @@ public:
 	                          SchemeEval& scm,
 	                          const Handle& surp_rb,
 	                          const std::string& mode,
-	                          unsigned max_conjuncts);
+	                          unsigned max_conjuncts,
+	                          double db_ratio=1.0);
 
 	/**
 	 * Populate the given atomspace with n nodes of a given type, named

--- a/tests/miner/SurprisingnessUTest.cxxtest
+++ b/tests/miner/SurprisingnessUTest.cxxtest
@@ -62,7 +62,9 @@ private:
 	// Some constants
 	Handle C0, C1;
 	
-	HandleSeq ure_surp(const std::string& mode, unsigned max_conjuncts);
+	HandleSeq ure_surp(const std::string& mode,
+	                   unsigned max_conjuncts,
+	                   double db_ratio=1.0);
 
 	// Load the ugly male soda drinker corpus and associate all
 	// inheritance links to _db_cpt.
@@ -117,6 +119,10 @@ public:
 	void test_nisurp_linkage_synthetic_7();
 	void test_nisurp_linkage_synthetic_8();
 
+	// Make sure that the db-ratio doesn't degrade too much the
+	// accuracy of the surprisingness measure
+	void test_nisurp_linkage_synthetic_db_ratio();
+
 	// Test surprisingness using bootstrapping to calculate
 	// probabilities
 	void test_nisurp_emp_prob_bs_1();
@@ -131,9 +137,12 @@ public:
 	void test_jsdsurp_ugly_man_soda_drinker();
 };
 
-HandleSeq SurprisingnessUTest::ure_surp(const std::string& mode, unsigned max_conjuncts)
+HandleSeq SurprisingnessUTest::ure_surp(const std::string& mode,
+                                        unsigned max_conjuncts,
+                                        double db_ratio)
 {
-	return MinerUTestUtils::ure_surp(_as, _scm, _surp_rb, mode, max_conjuncts);
+	return MinerUTestUtils::ure_surp(_as, _scm, _surp_rb, mode,
+	                                 max_conjuncts, db_ratio);
 }
 
 void SurprisingnessUTest::load_ugly_male_soda_drinker_corpus()
@@ -870,7 +879,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_3()
 
 	// Test normalized I-Surprisingness
 	std::string mode = "nisurp";
-	HandleSeq surp_results = ure_surp(mode, 2);
+	unsigned max_conjuncts = 2;
+	double db_ratio = 2;
+	HandleSeq surp_results = ure_surp(mode, max_conjuncts, db_ratio);
 	Handle expected = MinerUTestUtils::add_surp_eval(_as, mode, pattern);
 
 	logger().debug() << "surp_results = " << oc_to_string(surp_results);
@@ -997,7 +1008,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_5()
 
 	// Test normalized I-Surprisingness
 	std::string mode = "nisurp";
-	HandleSeq surp_results = ure_surp(mode, 3);
+	unsigned max_conjuncts = 3;
+	double db_ratio = 3;
+	HandleSeq surp_results = ure_surp(mode, max_conjuncts, db_ratio);
 	Handle expected = MinerUTestUtils::add_surp_eval(_as, mode, pattern);
 
 	logger().debug() << "surp_results = " << oc_to_string(surp_results);
@@ -1135,7 +1148,9 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_7()
 
 	// Test normalized I-Surprisingness
 	std::string mode = "nisurp";
-	HandleSeq surp_results = ure_surp(mode, 2);
+	unsigned max_conjuncts = 2;
+	double db_ratio = 2;
+	HandleSeq surp_results = ure_surp(mode, max_conjuncts, db_ratio);
 	Handle expected = MinerUTestUtils::add_surp_eval(_as, mode, pattern);
 
 	logger().debug() << "surp_results = " << oc_to_string(surp_results);
@@ -1215,6 +1230,56 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_8()
 	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.3);
 }
 
+// Like test_nisurp_linkage_synthetic_8() but make sure that db-ratio
+// doesn't degrade too much the accuracy of the surprisingness
+// measure.
+void SurprisingnessUTest::test_nisurp_linkage_synthetic_db_ratio()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create data base
+	populate_uniform_ternary_list_links(50, 0.1);
+
+	// Create pattern to measure surprisingness of
+	//
+	// LambdaLink
+	//   X Y Z W
+	//   PresentLink
+	//     List
+	//       X
+	//       Y
+	//       X
+	//     List
+	//       Z
+	//       W
+	//       X
+	Handle pattern = al(LAMBDA_LINK,
+	                    al(VARIABLE_SET, X, Y, Z, W),
+	                    al(PRESENT_LINK,
+	                       al(LIST_LINK, X, Y, X),
+	                       al(LIST_LINK, Z, W, X)));
+	MinerUTestUtils::add_minsup_eval(_as, pattern, 5, TruthValue::TRUE_TV());
+
+	// Test normalized I-Surprisingness
+	std::string mode = "nisurp";
+	double db_ratio = 0.5;
+	HandleSeq surp_results = ure_surp(mode, 2, db_ratio);
+	Handle expected = MinerUTestUtils::add_surp_eval(_as, mode, pattern);
+
+	logger().debug() << "surp_results = " << oc_to_string(surp_results);
+
+	TS_ASSERT(not surp_results.empty());
+
+	Handle surp_front = surp_results.front();
+
+	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "surp_front = " << oc_to_string(surp_front);
+
+	TS_ASSERT(content_eq(expected, surp_front));
+
+	TS_ASSERT_DELTA(0.0, expected->getTruthValue()->get_mean(), 0.3);
+}
+
 // Like test_nisurp_linkage_synthetic_3 but using bootstrapping to
 // calculate empirical probability and estimates.
 void SurprisingnessUTest::test_nisurp_emp_prob_bs_1()
@@ -1244,7 +1309,9 @@ void SurprisingnessUTest::test_nisurp_emp_prob_bs_1()
 
 	// Test normalized I-Surprisingness
 	std::string mode = "nisurp";
-	HandleSeq surp_results = ure_surp(mode, 2);
+	unsigned max_conjuncts = 2;
+	double db_ratio = 2;
+	HandleSeq surp_results = ure_surp(mode, max_conjuncts, db_ratio);
 	Handle expected = MinerUTestUtils::add_surp_eval(_as, mode, pattern);
 
 	logger().debug() << "surp_results = " << oc_to_string(surp_results);


### PR DESCRIPTION
Add `db-ratio` user option in the miner to modulate the target size of the maximum support to control subsampling during surprisingness measurement. Such options allows to increase efficiency (CPU and RAM) at the expense of accuracy, or increase accuracy at the expense of efficiency.

See `(help cog-mine)` for more info.