### PR TITLE
pattern matcher API has changed

### DIFF
--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -491,7 +491,7 @@ Handle MinerUtils::restricted_satisfying_set(const Handle& pattern,
 	// Run pattern matcher
 	SatisfyingSet sater(&tmp_db_as);
 	sater.max_results = ms;
-	GetLinkCast(gl)->satisfy(sater);
+	sater.satisfy(PatternLinkCast(gl));
 
 	QueueValuePtr qv(sater.get_result_queue());
 	HandleSeq hs(qv->to_handle_seq());


### PR DESCRIPTION
Required change for https://github.com/opencog/atomspace/pull/2658
The pattern matcher API changed, again.