### PR TITLE
Merge singnet/miner to opencog/miner

### DIFF
--- a/tests/miner/SurprisingnessUTest.cxxtest
+++ b/tests/miner/SurprisingnessUTest.cxxtest
@@ -1052,7 +1052,7 @@ void SurprisingnessUTest::test_nisurp_linkage_synthetic_6()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Create data base
-	populate_uniform_inheritance_links(1000, 0.01);
+	populate_uniform_inheritance_links(1000, 0.05);
 
 	// Create pattern to measure surprisingness of
 	//


### PR DESCRIPTION
It creates an ugly mountain in the git history just for single worthwhile commit https://github.com/opencog/miner/commit/d573ecb828fcceca0b70d04983779ec4b7ad3a16.

I'm tempted to just remake this commit on opencog/miner and then force push opencog/miner to singnet/miner, but why hide a scar? Better remember it I say.