### PR TITLE
Fix valuation

### DIFF
--- a/opencog/miner/HandleTree.cc
+++ b/opencog/miner/HandleTree.cc
@@ -52,7 +52,7 @@ bool content_eq(HandleTree::iterator itl, HandleTree::iterator itr)
 	return (sibl == itl.end()) == (sibr == itr.end());
 }
 
-bool content_is_in(const Handle& h, const HandleTree& ht)
+bool content_contains(const HandleTree& ht, const Handle& h)
 {
 	// TODO: optimize
 	for (const Handle& oh : ht)

--- a/opencog/miner/HandleTree.h
+++ b/opencog/miner/HandleTree.h
@@ -36,7 +36,7 @@ typedef std::map<Handle, HandleTree> HandleHandleTreeMap;
 
 bool content_eq(const HandleTree& htl, const HandleTree& htr);
 bool content_eq(HandleTree::iterator itl, HandleTree::iterator itr);
-bool content_is_in(const Handle& h, const HandleTree& ht);
+bool content_contains(const HandleTree& ht, const Handle& h);
 
 /**
  * Given a list of forests of patterns, merge them into a forest such

--- a/opencog/miner/MinerUtils.cc
+++ b/opencog/miner/MinerUtils.cc
@@ -74,7 +74,7 @@ HandleSetSeq MinerUtils::shallow_abstract(const Valuations& valuations,
 	// Recursive case
 	HandleSetSeq shabs_per_var{
 		// Don't specialize the focused variable if it is in ignore
-		content_is_in(valuations.focus_variable(), ignore) ?
+		content_contains(ignore, valuations.focus_variable()) ?
 		// We have to pass empty shallow abstractions for ignored variables to tell
 		// the shallow_specialize code to ignore them gracefully.
 		HandleSet()
@@ -413,7 +413,7 @@ Handle MinerUtils::compose_nocheck(const Handle& pattern, const HandlePair& var2
 	if (nameserver().isA(val->get_type(), VARIABLE_NODE)) {
 		Handle sa_decl = pvars.get_type_decl(var, val);
 		pvars.erase(var2pat.first);
-		if (not pvars.is_in_varset(val)) pvars.extend(Variables(sa_decl));
+		if (not pvars.varset_contains(val)) pvars.extend(Variables(sa_decl));
 	}
 	else {
 		pvars.erase(var2pat.first);
@@ -832,7 +832,7 @@ bool MinerUtils::is_pat_syntax_more_abstract(const Handle& l_pat,
 	Handle r_body = MinerUtils::get_body(r_pat);
 
 	// Let's first make sure that var is both in l_pat and r_pat
-	if (not l_vars.is_in_varset(var) or not r_vars.is_in_varset(var))
+	if (not l_vars.varset_contains(var) or not r_vars.varset_contains(var))
 		return false;
 
 	// Remove var from l_vars and r_vars to be considered as value
@@ -934,13 +934,13 @@ Handle MinerUtils::alpha_convert(const Handle& pattern,
 	// Detect collision between pattern_vars and other_vars
 	HandleMap aconv;
 	for (const Handle& var : pattern_vars.varset) {
-		if (other_vars.is_in_varset(var)) {
+		if (other_vars.varset_contains(var)) {
 			Handle nvar;
 			bool used;
 			do {
 				nvar = createNode(VARIABLE_NODE, randstr(var->get_name() + "-"));
 				// Make sure it is not in other_vars or pattern_vars
-				used = other_vars.is_in_varset(nvar) or pattern_vars.is_in_varset(nvar);
+				used = other_vars.varset_contains(nvar) or pattern_vars.varset_contains(nvar);
 			} while (used);
 			aconv[var] = nvar;
 		}
@@ -962,7 +962,7 @@ bool MinerUtils::is_value(const Unify::HandleCHandleMap::value_type& var_val,
                           const Variables& vars,
                           const Handle& var)
 {
-	return vars.is_in_varset(var_val.first)
+	return vars.varset_contains(var_val.first)
 		and (var_val.second == Unify::CHandle(var)
 		     or not var_val.second.is_free_variable());
 }
@@ -1493,14 +1493,6 @@ TypeSet MinerUtils::lwst_com_types(TypeSet tsets)
 	}
 	if (add_tp) common_types.insert(tp);
 	return common_types;
-}
-
-bool MinerUtils::content_is_in(const Handle& h, const HandleSeq& hs)
-{
-	for (const Handle& o : hs)
-		if (content_eq(h, o))
-			return true;
-	return false;
 }
 
 std::string oc_to_string(const HandleSeqSeqSeq& hsss,

--- a/opencog/miner/MinerUtils.h
+++ b/opencog/miner/MinerUtils.h
@@ -821,9 +821,6 @@ public:
 	static HandleValIntvlMap simple_unify(const HandleSeq &pat, const HandleSeq &val);
 
 	static void extend_seq_map(HandleValIntvlMap &sup, const HandleValIntvlMap &sub);
-
-	// Return true if h is in hs based on content_eq
-	static bool content_is_in(const Handle& h, const HandleSeq& hs);
 };
 
 /**

--- a/opencog/miner/Valuations.cc
+++ b/opencog/miner/Valuations.cc
@@ -193,7 +193,7 @@ Valuations::Valuations(const Variables& vars)
 const SCValuations& Valuations::get_scvaluations(const Handle& var) const
 {
 	for (const SCValuations& scv : scvs)
-		if (scv.variables.is_in_varset(var))
+		if (scv.variables.varset_contains(var))
 			return scv;
 	throw RuntimeException(TRACE_INFO, "There's likely a bug");
 }

--- a/opencog/miner/Valuations.h
+++ b/opencog/miner/Valuations.h
@@ -201,7 +201,7 @@ public:
 	 */
 	bool empty() const;
 
-	std::string to_string(const std::string& indent) const;
+	std::string to_string(const std::string& indent=empty_string) const;
 
 	SCValuationsSet scvs;
 

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -1253,7 +1253,7 @@ void MinerUTest::test_ABAB()
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
 	logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
 
-	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
+	TS_ASSERT(content_contains(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
 	Handle ure_results = ure_pm(db, 2, 10, initpat),
@@ -1296,7 +1296,7 @@ void MinerUTest::test_AAAA()
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
 	logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
 
-	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
+	TS_ASSERT(content_contains(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
 	Handle ure_results = ure_pm(db, 2, 50, initpat),
@@ -1465,7 +1465,7 @@ void MinerUTest::test_evaluation()
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
 	logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
 
-	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
+	TS_ASSERT(content_contains(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
 	Handle ure_results = ure_pm(db, 2, 5),
@@ -1801,7 +1801,7 @@ void MinerUTest::test_ignore_var_3()
 	// means that it hasn't been specialized).
 	for (const Handle& h : ure_results->getOutgoingSet()) {
 		Variables vars(MinerUtils::get_variables(MinerUTestUtils::get_pattern(h)));
-		TS_ASSERT(vars.is_in_varset(T));
+		TS_ASSERT(vars.varset_contains(T));
 	}
 }
 
@@ -1858,14 +1858,14 @@ void MinerUTest::test_2conjuncts_2()
 	// Define initpat
 	Handle initpat = MinerUtils::mk_pattern(VarXYZW, {InhXY, InhZW});
 
-//	// Run C++ pattern miner
-//	HandleTree cpp_results = cpp_pm(_as, 2, 2, initpat);
-//	Handle cpp_expected = MinerUtils::mk_pattern(VarXYZ, {InhXY, InhYZ});
-//
-//	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
-//	logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
-//
-//	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
+	// Run C++ pattern miner
+	HandleTree cpp_results = cpp_pm(_as, 2, 2, initpat);
+	Handle cpp_expected = MinerUtils::mk_pattern(VarXYZ, {InhXY, InhYZ});
+
+	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
+	logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
+
+	TS_ASSERT(content_contains(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
 	int ms = 2;
@@ -1908,7 +1908,7 @@ void MinerUTest::test_2conjuncts_3()
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
 	logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
 
-	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
+	TS_ASSERT(content_contains(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
 	int ms = 2;
@@ -1952,7 +1952,7 @@ void MinerUTest::test_2conjuncts_4()
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
 	logger().debug() << "cpp_expected = " << oc_to_string(cpp_expected);
 
-	TS_ASSERT(content_is_in(cpp_expected, cpp_results));
+	TS_ASSERT(content_contains(cpp_results, cpp_expected));
 
 	// Run URE pattern miner
 	int ms = 4;
@@ -2012,7 +2012,7 @@ void MinerUTest::test_2conjuncts_5()
 	logger().debug() << "results = " << oc_to_string(results);
 	logger().debug() << "non_expected = " << oc_to_string(non_expected);
 
-	TS_ASSERT(not content_is_in(non_expected, results));
+	TS_ASSERT(not content_contains(results, non_expected));
 }
 
 void MinerUTest::test_2conjuncts_6()
@@ -2184,7 +2184,7 @@ void MinerUTest::test_InferenceControl()
 
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
 
-	TS_ASSERT(content_is_in(expected, cpp_results));
+	TS_ASSERT(content_contains(cpp_results, expected));
 
 	// Run URE pattern miner
 	int ms = 2;
@@ -2244,7 +2244,7 @@ void MinerUTest::test_SodaDrinker()
 
 	logger().debug() << "cpp_results = " << oc_to_string(cpp_results);
 
-	TS_ASSERT(content_is_in(expected, cpp_results));
+	TS_ASSERT(content_contains(cpp_results, expected));
 
 	// Run URE pattern miner
 	int ms = 5;
@@ -2387,7 +2387,7 @@ void MinerUTest::xtest_lojban()
 	logger().debug() << "results = " << oc_to_string(results);
 	logger().debug() << "expected_pattern = " << oc_to_string(expected_pattern);
 
-	TS_ASSERT(content_is_in(expected_pattern, results));
+	TS_ASSERT(content_contains(results, expected_pattern));
 }
 
 void MinerUTest::test_vqa()

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -241,7 +241,7 @@ Handle MinerUTest::mk_nconjunct(unsigned n)
 bool MinerUTest::are_in(const HandleSeq& es, const HandleSeq& c)
 {
 	for (const Handle &e : es)
-		if (not is_in(e, c))
+		if (not contains(c, e))
 			return false;
 	return true;
 }
@@ -1069,7 +1069,7 @@ void MinerUTest::test_AB_redundant_cnj()
 	logger().debug() << "results = " << oc_to_string(results->getOutgoingSet());
 	logger().debug() << "no_expect = " << oc_to_string(no_expect);
 
-	TS_ASSERT(not is_in(no_expect, results->getOutgoingSet()));
+	TS_ASSERT(not contains(results->getOutgoingSet(), no_expect));
 }
 
 void MinerUTest::test_AB_AC()
@@ -1095,7 +1095,7 @@ void MinerUTest::test_AB_AC()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_AB_AC_BC()
@@ -1266,7 +1266,7 @@ void MinerUTest::test_ABAB()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_AAAA()
@@ -1309,7 +1309,7 @@ void MinerUTest::test_AAAA()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_glob()
@@ -1414,7 +1414,7 @@ void MinerUTest::test_long_transitivity()
 	logger().debug() << "results = " << oc_to_string(results);
 	logger().debug() << "expected = " << oc_to_string(expected);
 
-	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
+	TS_ASSERT(contains(results->getOutgoingSet(), expected));
 }
 
 void MinerUTest::test_no_transitivity()
@@ -1442,7 +1442,7 @@ void MinerUTest::test_no_transitivity()
 	logger().debug() << "results = " << oc_to_string(results);
 	logger().debug() << "not_expect = " << oc_to_string(not_expect);
 
-	TS_ASSERT(not is_in(not_expect, results->getOutgoingSet()));
+	TS_ASSERT(not contains(results->getOutgoingSet(), not_expect));
 }
 
 void MinerUTest::test_evaluation()
@@ -1474,7 +1474,7 @@ void MinerUTest::test_evaluation()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_variable_factorization()
@@ -1502,7 +1502,7 @@ void MinerUTest::test_variable_factorization()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_type_support_1()
@@ -1883,7 +1883,7 @@ void MinerUTest::test_2conjuncts_2()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_2conjuncts_3()
@@ -1926,7 +1926,7 @@ void MinerUTest::test_2conjuncts_3()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_2conjuncts_4()
@@ -1970,7 +1970,7 @@ void MinerUTest::test_2conjuncts_4()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_2conjuncts_5()
@@ -2199,7 +2199,7 @@ void MinerUTest::test_InferenceControl()
 
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 void MinerUTest::test_SodaDrinker()
@@ -2260,7 +2260,7 @@ void MinerUTest::test_SodaDrinker()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results);
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 }
 
 // Like test_SodaDrinker but starts with the most abstract pattern and
@@ -2322,7 +2322,7 @@ void MinerUTest::test_SodaDrinker_incremental()
 	logger().debug() << "ure_results = " << oc_to_string(ure_results->getOutgoingSet());
 	logger().debug() << "ure_expected = " << oc_to_string(ure_expected);
 
-	TS_ASSERT(is_in(ure_expected, ure_results->getOutgoingSet()));
+	TS_ASSERT(contains(ure_results->getOutgoingSet(), ure_expected));
 
 	// Test I-Surprisingness
 	std::string mode("nisurp-old");
@@ -2459,7 +2459,7 @@ void MinerUTest::test_vqa()
 	logger().debug() << "results = " << oc_to_string(results->getOutgoingSet());
 	logger().debug() << "expect = " << oc_to_string(expect);
 
-	TS_ASSERT(is_in(expect, results->getOutgoingSet()));
+	TS_ASSERT(contains(results->getOutgoingSet(), expect));
 }
 
 #undef al

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -1373,7 +1373,7 @@ void MinerUTest::test_transitivity()
 	logger().debug() << "results = " << oc_to_string(results);
 	logger().debug() << "expected = " << oc_to_string(expected);
 
-	TS_ASSERT(is_in(expected, results->getOutgoingSet()));
+	TS_ASSERT(contains(results->getOutgoingSet(), expected));
 }
 
 void MinerUTest::test_long_transitivity()

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -112,7 +112,10 @@ public:
 	 *
 	 * (Evaluation
 	 *   (Predicate "minsup")
-	 *   (List pattern (Concept "db") minsup))
+	 *   (List
+	 *     pattern
+	 *     db-cpt
+	 *     minsup))
 	 *
 	 * return pattern.
 	 *


### PR DESCRIPTION
There was a bug related to the fact that Handle::operator== is not content based, bringing problems when parts of the pattern are from different atomspaces.