### PR TITLE
Track AtomSpace API change.

### DIFF
--- a/opencog/miner/Miner.cc
+++ b/opencog/miner/Miner.cc
@@ -76,8 +76,7 @@ Miner::Miner(const MinerParameters& prm)
 HandleTree Miner::operator()(const AtomSpace& db_as)
 {
 	HandleSeq db;
-	db_as.get_handles_by_type(std::inserter(db, db.end()),
-	                          opencog::ATOM, true);
+	db_as.get_handles_by_type(db, opencog::ATOM, true);
 	return operator()(db);
 }
 

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -897,8 +897,7 @@ void MinerUTest::test_shallow_abstract()
 
 	// Define db
 	HandleSeq db;
-	_tmp_as.get_handles_by_type(std::inserter(db, db.end()),
-	                            opencog::ATOM, true);
+	_tmp_as.get_handles_by_type(db, opencog::ATOM, true);
 
 	// Define minimum support
 	int ms = 5;

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -163,8 +163,7 @@ Handle MinerUTestUtils::ure_pm(AtomSpace& as,
                                std::vector<std::string> ignore_set)
 {
 	HandleSeq db;
-	db_as.get_handles_by_type(std::inserter(db, db.end()),
-	                          opencog::ATOM, true);
+	db_as.get_handles_by_type(db, opencog::ATOM, true);
 	return ure_pm(as, scm, pm_rb, db, minsup, maximum_iterations, initpat,
 	              conjunction_expansion, max_conjuncts, max_variables,
 	              max_spcial_conjuncts, max_cnjexp_variables,

--- a/tests/miner/SurprisingnessUTest.cxxtest
+++ b/tests/miner/SurprisingnessUTest.cxxtest
@@ -150,9 +150,8 @@ void SurprisingnessUTest::load_ugly_male_soda_drinker_corpus()
 	std::string rs =
 		_scm.eval("(load-from-path \"ugly-male-soda-drinker-corpus.scm\")");
 	logger().debug() << "rs = " << rs;
-	HandleSet db;
-	_as.get_handles_by_type(std::inserter(db, db.end()),
-	                        opencog::INHERITANCE_LINK, true);
+	HandleSeq db;
+	_as.get_handles_by_type(db, opencog::INHERITANCE_LINK, true);
 	for (const Handle& dt : db)
 		al(MEMBER_LINK, dt, _db_cpt);
 }


### PR DESCRIPTION
The pull req opencog/atomspace#2864 removes the AtomTable. This has
a domino effect of some minor API changes, which includes gettting
handle sets.  The changed API will be slightly faster in two ways:
* It avoids a copy of a sequence of handles
* It avoids working with RB-trees of handles, in favor of vectors.
This might maybe improve performance in th miner ever so slightly.