### PR TITLE
Change all GroundedSchemas to do eager evaluation.

### DIFF
--- a/opencog/miner/scm/miner/rules/conjunction-expansion.scm
+++ b/opencog/miner/scm/miner/rules/conjunction-expansion.scm
@@ -92,7 +92,7 @@
   (define g (Quote (Lambda (Unquote g-vardecl) (Unquote g-body))))
   (define minsup-g (minsup-eval g db ms))
   ;; Formula
-  (define formula-name (string-append "scm: conjunction-expansion-"
+  (define formula-name (string-append "scm-eager: conjunction-expansion-"
                                       (if enforce-specialization
                                           "specialization-" "")
                                       "mv-" (number->string mv)

--- a/opencog/miner/scm/miner/rules/emp.scm
+++ b/opencog/miner/scm/miner/rules/emp.scm
@@ -69,7 +69,7 @@
       (Present minsup-pattern)
       (absolutely-true-eval minsup-pattern))
     (ExecutionOutput
-      (GroundedSchema "scm: emp-formula")
+      (GroundedSchema "scm-eager: emp-formula")
       (List
         ;; Conclusion
         (emp-eval pattern db)

--- a/opencog/miner/scm/miner/rules/est.scm
+++ b/opencog/miner/scm/miner/rules/est.scm
@@ -51,7 +51,7 @@
       (Present minsup-pattern)
       (absolutely-true-eval minsup-pattern))
     (ExecutionOutput
-      (GroundedSchema "scm: est-formula")
+      (GroundedSchema "scm-eager: est-formula")
       (List
         (est-eval pattern db)
         minsup-pattern)))))

--- a/opencog/miner/scm/miner/rules/i-surprisingness.scm
+++ b/opencog/miner/scm/miner/rules/i-surprisingness.scm
@@ -87,7 +87,7 @@
   (define typed-db (TypedVariable db ConceptT))
   (define typed-ms (TypedVariable ms NumberT))
   ;; Formula
-  (define formula-name (string-append "scm: " (symbol->string mode) "-formula"))
+  (define formula-name (string-append "scm-eager: " (symbol->string mode) "-formula"))
   (define formula (GroundedSchema formula-name))
 
   (if (< 1 nary)

--- a/opencog/miner/scm/miner/rules/jsd-surprisingness.scm
+++ b/opencog/miner/scm/miner/rules/jsd-surprisingness.scm
@@ -70,7 +70,7 @@
             (absolutely-true-eval minsup-e)
             (gt-zero-confidence-eval jsd-e))
           (ExecutionOutput
-            (GroundedSchema "scm: jsd-surprisingness-formula")
+            (GroundedSchema "scm-eager: jsd-surprisingness-formula")
             (List
               surp-e
               minsup-e

--- a/opencog/miner/scm/miner/rules/jsd.scm
+++ b/opencog/miner/scm/miner/rules/jsd.scm
@@ -47,7 +47,7 @@
       (gt-zero-confidence-eval emp)
       (gt-zero-confidence-eval est))
     (ExecutionOutput
-      (GroundedSchema "scm: jsd-formula")
+      (GroundedSchema "scm-eager: jsd-formula")
       (List
         (jsd-eval pattern db)
         emp

--- a/opencog/miner/scm/miner/rules/miner-rule-utils.scm
+++ b/opencog/miner/scm/miner/rules/miner-rule-utils.scm
@@ -57,7 +57,7 @@
 
 (define (unary-conjunction-eval body)
   (Evaluation
-    (GroundedPredicate "scm: unary-conjunction")
+    (GroundedPredicate "scm-eager: unary-conjunction")
     ;; Wrap the single argument in List in case it is itself a list
     (List body)))
 
@@ -70,7 +70,7 @@
 
 (define (unary-conjunction-pattern-eval pattern)
   (Evaluation
-    (GroundedPredicate "scm: unary-conjunction-pattern")
+    (GroundedPredicate "scm-eager: unary-conjunction-pattern")
     pattern))
 
 (define (equal-top x)

--- a/opencog/miner/scm/miner/rules/shallow-abstraction.scm
+++ b/opencog/miner/scm/miner/rules/shallow-abstraction.scm
@@ -75,7 +75,7 @@
       (Present minsup-g)
       (absolutely-true-eval minsup-g))
     (ExecutionOutput
-      (GroundedSchema "scm: shallow-abstraction-formula")
+      (GroundedSchema "scm-eager: shallow-abstraction-formula")
       (List
         (Set)               ; Cannot know the structure of the rule
                             ; conclusion in advance, because we don't

--- a/opencog/miner/scm/miner/rules/shallow-specialization.scm
+++ b/opencog/miner/scm/miner/rules/shallow-specialization.scm
@@ -76,7 +76,7 @@
       (Present minsup-pattern)
       (absolutely-true-eval minsup-pattern))
     (ExecutionOutput
-      (GroundedSchema (string-append "scm: shallow-specialization-mv-"
+      (GroundedSchema (string-append "scm-eager: shallow-specialization-mv-"
                                      (number->string mv)
                                      "-formula"))
       (List

--- a/opencog/miner/scm/miner/rules/specialization.scm
+++ b/opencog/miner/scm/miner/rules/specialization.scm
@@ -101,7 +101,7 @@
          (precond-2 (absolutely-true-eval shabs-eval))
          ;; Rewrite
          (rewrite (ExecutionOutput
-                    (GroundedSchema "scm: specialization-formula")
+                    (GroundedSchema "scm-eager: specialization-formula")
                     (List
                       (minsup-eval
                         (Quote (Put

--- a/tests/miner/MinerUTest.cxxtest
+++ b/tests/miner/MinerUTest.cxxtest
@@ -676,7 +676,7 @@ void MinerUTest::test_compose_2()
 		                al(EVALUATION_LINK,
 		                   X,
 		                   Y))),
-		gpn = an(GROUNDED_PREDICATE_NODE, "scm: absolutely-true"),
+		gpn = an(GROUNDED_PREDICATE_NODE, "scm-eager: absolutely-true"),
 		subpat = gpn;
 
 	Handle npat = MinerUtils::compose(pattern, {{X, subpat}}),

--- a/tests/miner/MinerUTestUtils.cc
+++ b/tests/miner/MinerUTestUtils.cc
@@ -114,7 +114,7 @@ HandleSeq MinerUTestUtils::get_patterns(const HandleSeq& minsup_evals)
 Handle MinerUTestUtils::add_abs_true_eval(AtomSpace& as, const Handle& h)
 {
 	return al(EVALUATION_LINK,
-	          an(GROUNDED_PREDICATE_NODE, "scm: absolutely-true"),
+	          an(GROUNDED_PREDICATE_NODE, "scm-eager: absolutely-true"),
 	          h);
 }
 

--- a/tests/miner/MinerUTestUtils.h
+++ b/tests/miner/MinerUTestUtils.h
@@ -128,7 +128,7 @@ public:
 	 * Add
 	 *
 	 * (Evaluation
-	 *   (GroundedPredicate "scm: absolutely-true")
+	 *   (GroundedPredicate "scm-eager: absolutely-true")
 	 *   h)
 	 *
 	 * to as.

--- a/tests/miner/scm/inference-control-corpus.scm
+++ b/tests/miner/scm/inference-control-corpus.scm
@@ -24,7 +24,7 @@
          (BindLink
             (AndLink
                (EvaluationLink
-                  (GroundedPredicateNode "scm: gt-zero-confidence")
+                  (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                   (EvaluationLink (stv 1 1)
                      (PredicateNode "alphabetical-order")
                      (ListLink
@@ -35,7 +35,7 @@
                )
             )
             (ExecutionOutputLink
-               (GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula")
+               (GroundedSchemaNode "scm-eager: conditional-full-instantiation-scope-formula")
                (ListLink
                   (InheritanceLink
                      (ConceptNode "a")
@@ -107,7 +107,7 @@
          (BindLink
             (AndLink
                (EvaluationLink
-                  (GroundedPredicateNode "scm: gt-zero-confidence")
+                  (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                   (EvaluationLink (stv 1 1)
                      (PredicateNode "alphabetical-order")
                      (ListLink
@@ -118,7 +118,7 @@
                )
             )
             (ExecutionOutputLink
-               (GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula")
+               (GroundedSchemaNode "scm-eager: conditional-full-instantiation-scope-formula")
                (ListLink
                   (InheritanceLink
                      (ConceptNode "a")
@@ -198,11 +198,11 @@
                )
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (VariableNode "$A-3ce0ef76")
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (SubsetLink
                   (VariableNode "$A-3ce0ef76")
                   (InheritanceLink
@@ -213,7 +213,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: modus-ponens-formula")
+            (GroundedSchemaNode "scm-eager: modus-ponens-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "a")
@@ -239,7 +239,7 @@
          (BindLink
             (AndLink
                (EvaluationLink
-                  (GroundedPredicateNode "scm: gt-zero-confidence")
+                  (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                   (EvaluationLink
                      (PredicateNode "alphabetical-order")
                      (ListLink
@@ -250,7 +250,7 @@
                )
             )
             (ExecutionOutputLink
-               (GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula")
+               (GroundedSchemaNode "scm-eager: conditional-full-instantiation-scope-formula")
                (ListLink
                   (InheritanceLink
                      (ConceptNode "d")
@@ -307,11 +307,11 @@
          (AndLink
             (VariableNode "$A-4d3401d5")
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (VariableNode "$A-4d3401d5")
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (ImplicationLink
                   (VariableNode "$A-4d3401d5")
                   (EvaluationLink
@@ -335,14 +335,14 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula")
+            (GroundedSchemaNode "scm-eager: conditional-full-instantiation-scope-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "d")
                   (ConceptNode "y")
                )
                (ExecutionOutputLink
-                  (GroundedSchemaNode "scm: modus-ponens-formula")
+                  (GroundedSchemaNode "scm-eager: modus-ponens-formula")
                   (ListLink
                      (EvaluationLink
                         (PredicateNode "alphabetical-order")
@@ -419,7 +419,7 @@
          (AndLink
             (VariableNode "$A-485f010a")
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (ImplicationLink
                   (VariableNode "$A-485f010a")
                   (InheritanceLink
@@ -429,7 +429,7 @@
                )
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (VariableNode "$A-485f010a")
             )
             (ImplicationLink
@@ -441,7 +441,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: modus-ponens-formula")
+            (GroundedSchemaNode "scm-eager: modus-ponens-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "a")
@@ -494,7 +494,7 @@
                )
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (SubsetLink
                   (VariableNode "$A-42e1ada")
                   (InheritanceLink
@@ -504,12 +504,12 @@
                )
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (VariableNode "$A-42e1ada")
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: modus-ponens-formula")
+            (GroundedSchemaNode "scm-eager: modus-ponens-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "a")
@@ -553,7 +553,7 @@
       (BindLink
          (AndLink
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (EvaluationLink (stv 1 1)
                   (PredicateNode "alphabetical-order")
                   (ListLink
@@ -564,7 +564,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula")
+            (GroundedSchemaNode "scm-eager: conditional-full-instantiation-scope-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "a")
@@ -632,11 +632,11 @@
          (AndLink
             (VariableNode "$A-2a3abe9e")
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (VariableNode "$A-2a3abe9e")
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (InheritanceLink
                   (VariableNode "$A-2a3abe9e")
                   (InheritanceLink
@@ -654,7 +654,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: modus-ponens-formula")
+            (GroundedSchemaNode "scm-eager: modus-ponens-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "a")
@@ -698,7 +698,7 @@
       (BindLink
          (AndLink
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (EvaluationLink
                   (PredicateNode "alphabetical-order")
                   (ListLink
@@ -709,7 +709,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula")
+            (GroundedSchemaNode "scm-eager: conditional-full-instantiation-scope-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "d")
@@ -799,7 +799,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: deduction-formula")
+            (GroundedSchemaNode "scm-eager: deduction-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "a")
@@ -852,11 +852,11 @@
                )
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (VariableNode "$A-51055a30")
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (InheritanceLink
                   (VariableNode "$A-51055a30")
                   (InheritanceLink
@@ -867,7 +867,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: modus-ponens-formula")
+            (GroundedSchemaNode "scm-eager: modus-ponens-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "a")
@@ -920,7 +920,7 @@
                )
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (SubsetLink
                   (VariableNode "$A-2df312ff")
                   (InheritanceLink
@@ -930,12 +930,12 @@
                )
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (VariableNode "$A-2df312ff")
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: modus-ponens-formula")
+            (GroundedSchemaNode "scm-eager: modus-ponens-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "d")
@@ -979,7 +979,7 @@
       (BindLink
          (AndLink
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (EvaluationLink (stv 1 1)
                   (PredicateNode "alphabetical-order")
                   (ListLink
@@ -990,7 +990,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: conditional-full-instantiation-scope-formula")
+            (GroundedSchemaNode "scm-eager: conditional-full-instantiation-scope-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "a")
@@ -1058,7 +1058,7 @@
          (AndLink
             (VariableNode "$A-5e64c5c0")
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (InheritanceLink
                   (VariableNode "$A-5e64c5c0")
                   (InheritanceLink
@@ -1068,7 +1068,7 @@
                )
             )
             (EvaluationLink
-               (GroundedPredicateNode "scm: gt-zero-confidence")
+               (GroundedPredicateNode "scm-eager: gt-zero-confidence")
                (VariableNode "$A-5e64c5c0")
             )
             (InheritanceLink
@@ -1080,7 +1080,7 @@
             )
          )
          (ExecutionOutputLink
-            (GroundedSchemaNode "scm: modus-ponens-formula")
+            (GroundedSchemaNode "scm-eager: modus-ponens-formula")
             (ListLink
                (InheritanceLink
                   (ConceptNode "d")


### PR DESCRIPTION
The AtomSpace no longer does eager evaluation by default.
Change all GroundedSchema to explicitly use eager evaluation,
since the SurprisingnessUTest seems to require this.
    
(There is a minor performance penalty associated with eager evaluation.)
