### PR TITLE
Get rid of CMP0037 for good

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,15 +9,8 @@
 # -- print pretty summary
 #
 
-# cogutils already requires 2.8.12.2, so may as well ask for that.
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12.2)
-IF (COMMAND CMAKE_POLICY)
-	CMAKE_POLICY(SET CMP0003 NEW)
-ENDIF (COMMAND CMAKE_POLICY)
-
-IF(CMAKE_VERSION VERSION_GREATER 3.0.2)
-	CMAKE_POLICY(SET CMP0037 OLD)
-ENDIF(CMAKE_VERSION VERSION_GREATER 3.0.2)
+# cogutils already requires 3.12, so may as well ask for that.
+CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
 
 PROJECT(miner)
 
@@ -220,11 +213,6 @@ IF (CXXTEST_FOUND)
 			COMMENT "Running tests..."
 		)
 	ENDIF (CMAKE_BUILD_TYPE STREQUAL "Coverage")
-
-	# When CMP00037 is finally turned off, just remove these two lines.
-	ADD_CUSTOM_TARGET(test)
-	ADD_DEPENDENCIES(test check)
-
 ENDIF (CXXTEST_FOUND)
 
 ADD_CUSTOM_TARGET(cscope

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To build and run the unit tests, from the `./build` directory enter
 ```
 Tests can be run in parallel as well:
 ```
-    make -j test ARGS=-j4
+    make -j check ARGS=-j4
 ```
 
 ### Install


### PR DESCRIPTION
It should be safe to remove, now; nothing uses it.